### PR TITLE
Converted all "ListenForever" methods to take a context argument.

### DIFF
--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -1,6 +1,7 @@
 package listener_test
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -25,8 +26,9 @@ func TestListenForClose(t *testing.T) {
 		t.Errorf("%v", err)
 		return
 	}
-	defer l.Stop()
-	go l.ListenForever()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go l.ListenForever(ctx)
 	ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777)
 	ldf := <-ldfChan
 	if !strings.HasSuffix(ldf.AbsoluteFileName, "/testfile") || !strings.HasPrefix(ldf.AbsoluteFileName, "/tmp/TestListenForClose.") {
@@ -49,8 +51,9 @@ func TestListenForMove(t *testing.T) {
 		t.Errorf("%v", err)
 		return
 	}
-	defer l.Stop()
-	go l.ListenForever()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go l.ListenForever(ctx)
 	err = os.Rename(dir+"/testfile", dir+"/subdir/testfile")
 	if err != nil {
 		t.Errorf("%v", err)
@@ -76,8 +79,9 @@ func TestListenInSubdir(t *testing.T) {
 		t.Errorf("%v", err)
 		return
 	}
-	defer l.Stop()
-	go l.ListenForever()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go l.ListenForever(ctx)
 	os.MkdirAll(dir+"/subdir/sub1/sub2", 0777)
 	// Sleep to allow the subdirectory listener to be established.
 	time.Sleep(100 * time.Millisecond)

--- a/listener/listener_whitebox_test.go
+++ b/listener/listener_whitebox_test.go
@@ -1,6 +1,7 @@
 package listener
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -61,8 +62,9 @@ func TestBadEvent(t *testing.T) {
 	defer os.RemoveAll(dir)
 	ldfChan := make(chan *tarcache.LocalDataFile)
 	l, err := Create(dir, ldfChan)
-	defer l.Stop()
-	go l.ListenForever()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go l.ListenForever(ctx)
 	l.events <- &MockEventInfo{}
 	time.Sleep(250 * time.Millisecond)
 	// No crash == test success

--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -216,6 +216,18 @@ func TestContextCancellation(t *testing.T) {
 	tarCache.ListenForever(ctx)
 }
 
+func TestChannelCloseCancellation(t *testing.T) {
+	uploader := fakeUploader{}
+	tarCache, inputChannel := New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
+	ctx := context.Background()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		close(inputChannel)
+	}()
+	// If this doesn't actually listen forever, then this test is a success.
+	tarCache.ListenForever(ctx)
+}
+
 func TestEmptyUpload(t *testing.T) {
 	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestEmptyUpload")
 	defer os.RemoveAll(tempdir)

--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -2,6 +2,7 @@ package tarcache
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"errors"
 	"io/ioutil"
@@ -162,7 +163,8 @@ func TestTimer(t *testing.T) {
 		AbsoluteFileName: tempdir + "/tinyfile",
 		Info:             fileStat,
 	}
-	go tarCache.ListenForever()
+	ctx := context.Background()
+	go tarCache.ListenForever(ctx)
 	channel <- &tinyFile
 	if uploader.calls != 0 {
 		t.Error("uploader.calls should be zero ", uploader.calls)
@@ -200,6 +202,18 @@ func TestTimer(t *testing.T) {
 	if uploader.calls != 1 {
 		t.Error("uploader.calls should be one ", uploader.calls)
 	}
+}
+
+func TestContextCancellation(t *testing.T) {
+	uploader := fakeUploader{}
+	tarCache, _ := New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		cancel()
+	}()
+	// If this doesn't actually listen forever, then this test is a success.
+	tarCache.ListenForever(ctx)
 }
 
 func TestEmptyUpload(t *testing.T) {


### PR DESCRIPTION
This allows them to be cancelled in a uniform manner, and moves things to a standard Go idiom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/21)
<!-- Reviewable:end -->
