### PR TITLE
Adds a filter to count bad filenames.

### DIFF
--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -322,3 +322,25 @@ func TestUnreadableFile(t *testing.T) {
 		t.Error("We added a nonexistent file to the tarCache.")
 	}
 }
+
+func TestLintFilename(t *testing.T) {
+	for _, badString := range []string{
+		"/gfdgf/../fsdfds/data.txt",
+		"file.txt; rm -Rf *",
+		"dir/.gz",
+		"dir/.../file.gz",
+		"dir/only_a_dir/",
+	} {
+		if lintFilename(badString) == nil {
+			t.Errorf("Should have had a lint error on %q", badString)
+		}
+	}
+	for _, goodString := range []string{
+		"ndt/2009/03/13/file.gz",
+		"experiment_2/2013/01/01/subdirectory/file.tgz",
+	} {
+		if warning := lintFilename(goodString); warning != nil {
+			t.Errorf("Linter gave warning %v on %q", warning, goodString)
+		}
+	}
+}


### PR DESCRIPTION
We want to save all generated data, but we also have best practices. This code adds a filename linter to check best practices for the filenames of saved data, and it also adds a prometheus counter to count how many files we find with filenames that don't follow our best practices.  Ideally this counter will always be zero.