### PR TITLE
Adds a success counter and linting of metrics.

### DIFF
--- a/pusher_integration_test.go
+++ b/pusher_integration_test.go
@@ -63,7 +63,6 @@ func TestMainAndPrometheusMetrics(t *testing.T) {
 		if err != nil {
 			t.Errorf("Could not read metrics: %v", err)
 		}
-		log.Println(string(metricBytes))
 		metricsLinter := promlint.New(bytes.NewBuffer(metricBytes))
 		problems, err := metricsLinter.Lint()
 		if err != nil {

--- a/pusher_integration_test.go
+++ b/pusher_integration_test.go
@@ -63,6 +63,7 @@ func TestMainAndPrometheusMetrics(t *testing.T) {
 		if err != nil {
 			t.Errorf("Could not read metrics: %v", err)
 		}
+		log.Println(string(metricBytes))
 		metricsLinter := promlint.New(bytes.NewBuffer(metricBytes))
 		problems, err := metricsLinter.Lint()
 		if err != nil {

--- a/tarcache/tarcache.go
+++ b/tarcache/tarcache.go
@@ -101,6 +101,13 @@ var (
 		Name: "pusher_strange_filenames_total",
 		Help: "The number of files we have seen with names that looked surprising in some way",
 	})
+	pusherSuccesses = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_successes_total",
+			Help: "The number of times we have either successfully uploaded data or successfully had no data to upload.",
+		},
+		[]string{"reason"},
+	)
 )
 
 func init() {
@@ -119,6 +126,9 @@ func init() {
 	prometheus.MustRegister(pusherCurrentTarfileFileCount)
 	prometheus.MustRegister(pusherCurrentTarfileSize)
 	prometheus.MustRegister(pusherStrangeFilenames)
+	prometheus.MustRegister(pusherSuccesses)
+	pusherSuccesses.WithLabelValues("empty_upload")
+	pusherSuccesses.WithLabelValues("tarfile_uploaded")
 }
 
 // A LocalDataFile holds all the information we require about a file.
@@ -272,6 +282,7 @@ func (t *TarCache) uploadAndDelete() {
 func (t *tarfile) uploadAndDelete(uploader uploader.Uploader) {
 	if len(t.members) == 0 {
 		pusherEmptyUploads.Inc()
+		pusherSuccesses.WithLabelValues("empty_upload").Inc()
 		log.Println("uploadAndDelete called on an empty tarfile.")
 		return
 	}
@@ -288,6 +299,7 @@ func (t *tarfile) uploadAndDelete(uploader uploader.Uploader) {
 		"upload",
 	)
 	pusherTarfilesUploaded.Inc()
+	pusherSuccesses.WithLabelValues("tarfile_uploaded").Inc()
 	for _, file := range t.members {
 		// If the file can't be removed, then it either was already removed or the
 		// remove call failed for some unknown reason (permissions, maybe?). If the


### PR DESCRIPTION
If the success counter does not increment in a long time, then the pusher should be regarded as unhealthy.

Also, this now lints all metrics as part of the smoke-test for the `main()` function.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/28)
<!-- Reviewable:end -->
