### PR TITLE
LocalDataFile is now just a string.

### DIFF
--- a/finder/findfiles_test.go
+++ b/finder/findfiles_test.go
@@ -25,22 +25,22 @@ func TestFindForever(t *testing.T) {
 	newtime = time.Now().Add(time.Duration(-12) * time.Hour)
 	rtx.Must(os.Chtimes(tempdir+"/next_oldest_file", newtime, newtime), "Chtimes failed")
 	// Set up the receiver channel.
-	foundFiles := make(chan *tarcache.LocalDataFile)
+	foundFiles := make(chan tarcache.LocalDataFile)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go finder.FindForever(ctx, tempdir, time.Duration(6)*time.Hour, foundFiles, 1*time.Microsecond)
-	localfiles := []*tarcache.LocalDataFile{
+	localfiles := []tarcache.LocalDataFile{
 		<-foundFiles,
 		<-foundFiles,
 	}
 	if len(localfiles) != 2 {
 		t.Errorf("len(localfiles) (%d) != 2", len(localfiles))
 	}
-	if localfiles[0].AbsoluteFileName != tempdir+"/oldest_file" {
-		t.Errorf("wrong name[0]: %s", localfiles[0].AbsoluteFileName)
+	if string(localfiles[0]) != tempdir+"/oldest_file" {
+		t.Errorf("wrong name[0]: %s", localfiles[0])
 	}
-	if localfiles[1].AbsoluteFileName != tempdir+"/next_oldest_file" {
-		t.Errorf("wrong name[1]: %s", localfiles[1].AbsoluteFileName)
+	if string(localfiles[1]) != tempdir+"/next_oldest_file" {
+		t.Errorf("wrong name[1]: %s", localfiles[1])
 	}
 }
 

--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -20,7 +20,7 @@ func TestListenForClose(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(dir)
-	ldfChan := make(chan *tarcache.LocalDataFile)
+	ldfChan := make(chan tarcache.LocalDataFile)
 	l, err := listener.Create(dir, ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)
@@ -31,8 +31,8 @@ func TestListenForClose(t *testing.T) {
 	go l.ListenForever(ctx)
 	ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777)
 	ldf := <-ldfChan
-	if !strings.HasSuffix(ldf.AbsoluteFileName, "/testfile") || !strings.HasPrefix(ldf.AbsoluteFileName, "/tmp/TestListenForClose.") {
-		t.Errorf("Bad filename: %q\n", ldf.AbsoluteFileName)
+	if !strings.HasSuffix(string(ldf), "/testfile") || !strings.HasPrefix(string(ldf), "/tmp/TestListenForClose.") {
+		t.Errorf("Bad filename: %v\n", ldf)
 	}
 }
 
@@ -45,7 +45,7 @@ func TestListenForMove(t *testing.T) {
 	defer os.RemoveAll(dir)
 	os.Mkdir(dir+"/subdir", 0777)
 	ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777)
-	ldfChan := make(chan *tarcache.LocalDataFile)
+	ldfChan := make(chan tarcache.LocalDataFile)
 	l, err := listener.Create(dir+"/subdir", ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)
@@ -60,8 +60,8 @@ func TestListenForMove(t *testing.T) {
 		return
 	}
 	ldf := <-ldfChan
-	if !strings.HasSuffix(ldf.AbsoluteFileName, "/subdir/testfile") || !strings.HasPrefix(ldf.AbsoluteFileName, "/tmp/TestListenForMove.") {
-		t.Errorf("Bad filename: %q\n", ldf.AbsoluteFileName)
+	if !strings.HasSuffix(string(ldf), "/subdir/testfile") || !strings.HasPrefix(string(ldf), "/tmp/TestListenForMove.") {
+		t.Errorf("Bad filename: %v\n", ldf)
 	}
 }
 
@@ -73,7 +73,7 @@ func TestListenInSubdir(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	os.Mkdir(dir+"/subdir", 0777)
-	ldfChan := make(chan *tarcache.LocalDataFile)
+	ldfChan := make(chan tarcache.LocalDataFile)
 	l, err := listener.Create(dir+"/subdir", ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)
@@ -87,8 +87,8 @@ func TestListenInSubdir(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 	ioutil.WriteFile(dir+"/subdir/sub1/sub2/testfile", []byte("testdata"), 0777)
 	ldf := <-ldfChan
-	if dir+"/subdir/sub1/sub2/testfile" != ldf.AbsoluteFileName {
-		t.Errorf("Bad filename: %q\n", ldf.AbsoluteFileName)
+	if dir+"/subdir/sub1/sub2/testfile" != string(ldf) {
+		t.Errorf("Bad filename: %v\n", ldf)
 	}
 }
 
@@ -99,7 +99,7 @@ func TestCreateOnBadDir(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(dir)
-	ldfChan := make(chan *tarcache.LocalDataFile)
+	ldfChan := make(chan tarcache.LocalDataFile)
 	l, err := listener.Create(dir+"/doesnotexist", ldfChan)
 	if l != nil || err == nil {
 		t.Error("Should have had an error")

--- a/listener/listener_whitebox_test.go
+++ b/listener/listener_whitebox_test.go
@@ -20,22 +20,8 @@ func failOnOpen(name string) (*os.File, error) {
 func TestOsOpenFailure(t *testing.T) {
 	osOpen = failOnOpen
 	defer func() { osOpen = os.Open }()
-	ptr, err := convertEventInfoToLocalDataFile("")
-	if ptr != nil || err == nil {
-		t.Error("convertEventInfo should have had an error but did not")
-	}
-}
-
-func openFileThatFailsOnStat(name string) (*os.File, error) {
-	return nil, nil
-}
-
-func TestStatFailure(t *testing.T) {
-	osOpen = openFileThatFailsOnStat
-	defer func() { osOpen = os.Open }()
-	ptr, err := convertEventInfoToLocalDataFile("")
-	if ptr != nil || err == nil {
-		t.Error("convertEventInfo should have had an error but did not")
+	if isOpenable("") {
+		t.Error("isOpenable should return false")
 	}
 }
 
@@ -60,7 +46,7 @@ func TestBadEvent(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(dir)
-	ldfChan := make(chan *tarcache.LocalDataFile)
+	ldfChan := make(chan tarcache.LocalDataFile)
 	l, err := Create(dir, ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)

--- a/tarcache/tarcache.go
+++ b/tarcache/tarcache.go
@@ -126,7 +126,7 @@ func init() {
 	prometheus.MustRegister(pusherSuccessTimestamp)
 }
 
-// A LocalDataFile is the full absolute pathname of a data file.
+// A LocalDataFile is the absolute pathname of a data file.
 type LocalDataFile string
 
 // TarCache contains everything you need to incrementally create a tarfile.


### PR DESCRIPTION
The os.FileInfo data member was never used. This enabled lots of simplification.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/32)
<!-- Reviewable:end -->
