### PR TITLE
Use microsecond-granularity timestamps.

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -112,7 +112,7 @@ The file channel takes in the information about files that should be uploaded an
 
 The namer generates names for the tarfiles based on the mlab node name, the experiment name, and the UTC timestamp of the upload time. The upload time is used (as opposed to the minimum file mtime or anything else like that) because it is the only counter that (local time adjustments aside) can be depended upon to monotonically increase, and as such is guaranteed not to generate collisions in the produced file name. The names it generates should look like:
 
-`ndt/2006/01/02/20060102T150405.000Z-mlab1-lax03-ndt.tgz`
+`ndt/2006/01/02/20060102T150405.000000Z-mlab1-lax03-ndt.tgz`
 
 ### 5.5. Tar Cache
 

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -38,6 +38,6 @@ func New(experiment string, nodeName string) (Namer, error) {
 // ObjectName returns a string (with a leading '/') representing the correct
 // filename for an uploaded tarfile in a bucket.
 func (n namer) ObjectName(t time.Time) string {
-	timestring := t.Format("2006/01/02/20060102T150405.000Z")
+	timestring := t.Format("2006/01/02/20060102T150405.000000Z")
 	return (n.experiment + "/" + timestring + "-" + n.node + "-" + n.site + "-" + n.experiment + ".tgz")
 }

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -13,12 +13,12 @@ func TestFilenameGeneration(t *testing.T) {
 		out string
 	}{
 		{
-			in:  time.Date(2018, 5, 6, 15, 1, 2, 44000000, time.UTC),
-			out: "exp/2018/05/06/20180506T150102.044Z-mlab6-lga0t-exp.tgz",
+			in:  time.Date(2018, 5, 6, 15, 1, 2, 44001000, time.UTC),
+			out: "exp/2018/05/06/20180506T150102.044001Z-mlab6-lga0t-exp.tgz",
 		},
 		{
 			in:  time.Date(2008, 1, 1, 0, 0, 0, 0, time.UTC),
-			out: "exp/2008/01/01/20080101T000000.000Z-mlab6-lga0t-exp.tgz",
+			out: "exp/2008/01/01/20080101T000000.000000Z-mlab6-lga0t-exp.tgz",
 		},
 	}
 	namer, err := namer.New("exp", "mlab6.lga0t")
@@ -43,7 +43,7 @@ func TestNew(t *testing.T) {
 		{
 			name:        "success",
 			nodeName:    "mlab5.abc0t.measurement-lab.org",
-			wantObjName: "fake-experiment/2011/03/04/20110304T124500.000Z-mlab5-abc0t-fake-experiment.tgz",
+			wantObjName: "fake-experiment/2011/03/04/20110304T124500.000000Z-mlab5-abc0t-fake-experiment.tgz",
 		},
 		{
 			name:     "failure-machine-too-short",


### PR DESCRIPTION
It feels right to err on the side of caution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/34)
<!-- Reviewable:end -->
