### PR TITLE
Multiple datatypes per instance of pusher.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
 # This assumes we never have a file named __coverage.cov checked in. A
 # good assumption, but one we should note.
 - GCLOUD_PROJECT=mlab-testing
-    go test -v -covermode=count -coverprofile=__coverage.cov ./...
+    go test -v -covermode=count -coverprofile=__coverage.cov -coverpkg=./... ./...
 - $HOME/gopath/bin/goveralls -coverprofile=__coverage.cov -service=travis-ci

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -52,9 +52,9 @@ In exchange for obeying that contract, the experimenter gets an extremely simple
 
 * One data file per test result (e.g. one upload test should create one file)
 
-* File names must be written in a date-and-time-specifying subdirectory format like `/var/spool/myexperiment/2008/04/22/20080422Z15:04:05.0001212.results.txt`. If you do this, pusher will make the additional guarantee that files written to the directory YYYY/MM/DD will appear in a tarfile contained in the directory path YYYY/MM/DD on Google Cloud Storage.
+* File names must be written in a date-and-time-specifying subdirectory format like `/var/spool/myexperiment/datatype/2008/04/22/20080422Z15:04:05.0001212.results.txt`. If you do this, pusher will make the additional guarantee that files written to the directory datatype/YYYY/MM/DD will appear in a tarfile contained in the directory path datatype/YYYY/MM/DD on Google Cloud Storage.  We also intend that the name of the datatype correspond to the name of the tables in BigQuery, and that the experiment name will be the leading part of the dns name of the host on which the experiment is run.  Short and good standard names for experiments and datatypes make a lot of things simpler.
 
-* Feel free to put IP addresses in the file name if that makes sense for your experiment, but make sure your code works with both IPv4 and IPv6.
+* Feel free to put IP addresses in the file name if that makes sense for your experiment, but make sure your filename generation code works with both IPv4 and IPv6.
 
 * For filenames, stick with the alphabet, numbers, underscores, colons, periods, and dashes - and even then, be careful with the periods to ensure your filenames never start with a period or have two periods in a row.
 
@@ -114,7 +114,7 @@ The file channel takes in the information about files that should be uploaded an
 
 The namer generates names for the tarfiles based on the mlab node name, the experiment name, the subdirectory the data was written to, and the UTC timestamp of the upload time. The upload time is used (as opposed to the minimum file mtime or anything else like that) because it is the only counter that (local time adjustments aside) can be depended upon to monotonically increase, and as such is guaranteed not to generate collisions in the produced file name. The names it generates should look like:
 
-`ndt/2006/01/02/20161112T150405.000000Z-mlab1-lax03-ndt.tgz`
+`ndt/2006/01/02/20161112T150405.000000Z-summary-mlab1-lax03-ndt.tgz`
 
 The date in the path directories is the date the data is about (according to the experiment), and the timestamp in the filename is the time at which the file was uploaded.
 

--- a/filename/filename.go
+++ b/filename/filename.go
@@ -1,3 +1,6 @@
+// Package filename provides types for representing files on disk and files
+// inside of tarfiles.  Using these types can help ensure that function
+// arguments don't mix up the two categories.
 package filename
 
 import (
@@ -54,7 +57,7 @@ func (l Internal) Lint() error {
 	if invalidChars.MatchString(name) {
 		return fmt.Errorf("Strange characters detected in the filename %q", name)
 	}
-	recommendedFormat := regexp.MustCompile(`^[a-zA-Z0-9_-]+/20[0-9][0-9]/[0-9]{2}/[0-9]{2}`)
+	recommendedFormat := regexp.MustCompile(`^20[0-9][0-9]/[0-9]{2}/[0-9]{2}`)
 	if !recommendedFormat.MatchString(d) {
 		return fmt.Errorf("Directory structure does not mirror our best practices for file %v", name)
 	}

--- a/filename/filename.go
+++ b/filename/filename.go
@@ -1,0 +1,62 @@
+package filename
+
+import (
+	"fmt"
+	"log"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// System contains a filename suitable for passing directly to os.Remove.
+type System string
+
+// Internal removes the path information that is not relevant to the tarfile.
+func (s System) Internal(rootDirectory System) Internal {
+	return Internal(strings.TrimPrefix(string(s), string(rootDirectory)))
+}
+
+// Internal is the pathname of a data file inside of the tarfile.
+type Internal string
+
+// Subdir returns the subdirectory of the Internal filename, up to 3 levels
+// deep. It is only guaranteed to work right on relative path names, suitable
+// for inclusion in tarfiles.
+func (l Internal) Subdir() string {
+	dirs := strings.Split(string(l), "/")
+	if len(dirs) <= 1 {
+		log.Printf("File handed to the tarcache is not in a subdirectory: %v is not split by /", l)
+		return ""
+	}
+	k := len(dirs) - 1
+	if k > 3 {
+		k = 3
+	}
+	return strings.Join(dirs[:k], "/")
+}
+
+// Lint returns nil if the file has a normal name, and an explanatory error
+// about why the name is strange otherwise.
+func (l Internal) Lint() error {
+	name := string(l)
+	cleaned := path.Clean(name)
+	if cleaned != name {
+		return fmt.Errorf("The cleaned up path %q did not match the name of the passed-in file %q", cleaned, name)
+	}
+	d, f := path.Split(name)
+	if strings.HasPrefix(f, ".") {
+		return fmt.Errorf("Hidden file detected: %q", name)
+	}
+	if strings.Contains(name, "..") {
+		return fmt.Errorf("Too many dots in %v", name)
+	}
+	invalidChars := regexp.MustCompile(`[^a-zA-Z0-9/:._-]`)
+	if invalidChars.MatchString(name) {
+		return fmt.Errorf("Strange characters detected in the filename %q", name)
+	}
+	recommendedFormat := regexp.MustCompile(`^[a-zA-Z0-9_-]+/20[0-9][0-9]/[0-9]{2}/[0-9]{2}`)
+	if !recommendedFormat.MatchString(d) {
+		return fmt.Errorf("Directory structure does not mirror our best practices for file %v", name)
+	}
+	return nil
+}

--- a/filename/filename_test.go
+++ b/filename/filename_test.go
@@ -6,6 +6,21 @@ import (
 	"github.com/m-lab/pusher/filename"
 )
 
+func TestInternal(t *testing.T) {
+	for _, test := range []struct{ in, out string }{
+		{in: "/var/spool/ndt/2009/01/01/tes/", out: "2009/01/01/tes/"},
+		{in: "/var/spool/ndt/2009/01/test", out: "2009/01/test"},
+		{in: "/var/spool/ndt/2009/test", out: "2009/test"},
+		{in: "/var/spool/ndt/test", out: "test"},
+		{in: "/var/spool/ndt/2009/01/01/subdir/test", out: "2009/01/01/subdir/test"},
+	} {
+		out := filename.System(test.in).Internal(filename.System("/var/spool/ndt/"))
+		if string(out) != test.out {
+			t.Errorf("The subdirectory should have been %q but was %q", test.out, out)
+		}
+	}
+}
+
 func TestLint(t *testing.T) {
 	for _, badString := range []string{
 		"/gfdgf/../fsdfds/data.txt",
@@ -28,6 +43,7 @@ func TestLint(t *testing.T) {
 		}
 	}
 }
+
 func TestSubdir(t *testing.T) {
 	for _, test := range []struct{ in, out string }{
 		{in: "2009/01/01/tes/", out: "2009/01/01"},

--- a/filename/filename_test.go
+++ b/filename/filename_test.go
@@ -1,0 +1,44 @@
+package filename_test
+
+import (
+	"testing"
+
+	"github.com/m-lab/pusher/filename"
+)
+
+func TestLint(t *testing.T) {
+	for _, badString := range []string{
+		"/gfdgf/../fsdfds/data.txt",
+		"file.txt; rm -Rf *",
+		"dir/.gz",
+		"dir/.../file.gz",
+		"dir/only_a_dir/",
+		"ndt/2009/03/ab/file.gz",
+	} {
+		if filename.Internal(badString).Lint() == nil {
+			t.Errorf("Should have had a lint error on %q", badString)
+		}
+	}
+	for _, goodString := range []string{
+		"ndt/2009/03/13/file.gz",
+		"experiment_2/2013/01/01/subdirectory/file.tgz",
+	} {
+		if warning := filename.Internal(goodString).Lint(); warning != nil {
+			t.Errorf("Linter gave warning %v on %q", warning, goodString)
+		}
+	}
+}
+func TestSubdir(t *testing.T) {
+	for _, test := range []struct{ in, out string }{
+		{in: "2009/01/01/tes/", out: "2009/01/01"},
+		{in: "2009/01/test", out: "2009/01"},
+		{in: "2009/test", out: "2009"},
+		{in: "test", out: ""},
+		{in: "2009/01/01/subdir/test", out: "2009/01/01"},
+	} {
+		out := filename.Internal(test.in).Subdir()
+		if out != test.out {
+			t.Errorf("The subdirectory should have been %q but was %q", test.out, out)
+		}
+	}
+}

--- a/filename/filename_test.go
+++ b/filename/filename_test.go
@@ -8,13 +8,13 @@ import (
 
 func TestInternal(t *testing.T) {
 	for _, test := range []struct{ in, out string }{
-		{in: "/var/spool/ndt/2009/01/01/tes/", out: "2009/01/01/tes/"},
-		{in: "/var/spool/ndt/2009/01/test", out: "2009/01/test"},
-		{in: "/var/spool/ndt/2009/test", out: "2009/test"},
-		{in: "/var/spool/ndt/test", out: "test"},
-		{in: "/var/spool/ndt/2009/01/01/subdir/test", out: "2009/01/01/subdir/test"},
+		{in: "/var/spool/ndt/summary/2009/01/01/tes/", out: "2009/01/01/tes/"},
+		{in: "/var/spool/ndt/summary/2009/01/test", out: "2009/01/test"},
+		{in: "/var/spool/ndt/summary/2009/test", out: "2009/test"},
+		{in: "/var/spool/ndt/summary/test", out: "test"},
+		{in: "/var/spool/ndt/summary/2009/01/01/subdir/test", out: "2009/01/01/subdir/test"},
 	} {
-		out := filename.System(test.in).Internal(filename.System("/var/spool/ndt/"))
+		out := filename.System(test.in).Internal(filename.System("/var/spool/ndt/summary/"))
 		if string(out) != test.out {
 			t.Errorf("The subdirectory should have been %q but was %q", test.out, out)
 		}
@@ -29,14 +29,17 @@ func TestLint(t *testing.T) {
 		"dir/.../file.gz",
 		"dir/only_a_dir/",
 		"ndt/2009/03/ab/file.gz",
+		"2009/03/ab/file.gz",
+		"ndt/summary/2009/03/01/file.gz",
+		"summary/2009/03/01/file.gz",
 	} {
 		if filename.Internal(badString).Lint() == nil {
 			t.Errorf("Should have had a lint error on %q", badString)
 		}
 	}
 	for _, goodString := range []string{
-		"ndt/2009/03/13/file.gz",
-		"experiment_2/2013/01/01/subdirectory/file.tgz",
+		"2009/03/13/file.gz",
+		"2013/01/01/subdirectory/file.tgz",
 	} {
 		if warning := filename.Internal(goodString).Lint(); warning != nil {
 			t.Errorf("Linter gave warning %v on %q", warning, goodString)

--- a/finder/findfiles_test.go
+++ b/finder/findfiles_test.go
@@ -7,9 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/pusher/tarcache"
-
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/finder"
 )
 
@@ -26,11 +25,11 @@ func TestFindForever(t *testing.T) {
 	newtime = time.Now().Add(time.Duration(-12) * time.Hour)
 	rtx.Must(os.Chtimes(tempdir+"/next_oldest_file", newtime, newtime), "Chtimes failed")
 	// Set up the receiver channel.
-	foundFiles := make(chan tarcache.SystemFilename)
+	foundFiles := make(chan filename.System)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go finder.FindForever(ctx, tempdir, time.Duration(6)*time.Hour, foundFiles, 1*time.Microsecond)
-	localfiles := []tarcache.SystemFilename{
+	go finder.FindForever(ctx, filename.System(tempdir), time.Duration(6)*time.Hour, foundFiles, 1*time.Microsecond)
+	localfiles := []filename.System{
 		<-foundFiles,
 		<-foundFiles,
 	}

--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -8,8 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/pusher/tarcache"
-
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/listener"
 )
 
@@ -20,8 +19,8 @@ func TestListenForClose(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(dir)
-	ldfChan := make(chan tarcache.SystemFilename)
-	l, err := listener.Create(dir, ldfChan)
+	ldfChan := make(chan filename.System)
+	l, err := listener.Create(filename.System(dir), ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)
 		return
@@ -45,8 +44,8 @@ func TestListenForMove(t *testing.T) {
 	defer os.RemoveAll(dir)
 	os.Mkdir(dir+"/subdir", 0777)
 	ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777)
-	ldfChan := make(chan tarcache.SystemFilename)
-	l, err := listener.Create(dir+"/subdir", ldfChan)
+	ldfChan := make(chan filename.System)
+	l, err := listener.Create(filename.System(dir+"/subdir"), ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)
 		return
@@ -73,8 +72,8 @@ func TestListenInSubdir(t *testing.T) {
 	}
 	defer os.RemoveAll(dir)
 	os.Mkdir(dir+"/subdir", 0777)
-	ldfChan := make(chan tarcache.SystemFilename)
-	l, err := listener.Create(dir+"/subdir", ldfChan)
+	ldfChan := make(chan filename.System)
+	l, err := listener.Create(filename.System(dir+"/subdir"), ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)
 		return
@@ -99,8 +98,8 @@ func TestCreateOnBadDir(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(dir)
-	ldfChan := make(chan tarcache.SystemFilename)
-	l, err := listener.Create(dir+"/doesnotexist", ldfChan)
+	ldfChan := make(chan filename.System)
+	l, err := listener.Create(filename.System(dir+"/doesnotexist"), ldfChan)
 	if l != nil || err == nil {
 		t.Error("Should have had an error")
 	}

--- a/listener/listener_whitebox_test.go
+++ b/listener/listener_whitebox_test.go
@@ -8,8 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/m-lab/pusher/tarcache"
-
+	"github.com/m-lab/pusher/filename"
 	"github.com/rjeczalik/notify"
 	"golang.org/x/sys/unix"
 )
@@ -47,8 +46,8 @@ func TestBadEvent(t *testing.T) {
 		return
 	}
 	defer os.RemoveAll(dir)
-	ldfChan := make(chan tarcache.SystemFilename)
-	l, err := Create(dir, ldfChan)
+	ldfChan := make(chan filename.System)
+	l, err := Create(filename.System(dir), ldfChan)
 	if err != nil {
 		t.Errorf("%v", err)
 		return

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -3,6 +3,7 @@ package namer
 
 import (
 	"fmt"
+	"path"
 	"strings"
 	"time"
 )
@@ -14,11 +15,11 @@ type Namer interface {
 
 // This is a specific namer used for M-Lab experiments.
 type namer struct {
-	experiment, node, site string
+	datatype, experiment, node, site string
 }
 
 // New creates a new Namer for the given experiment, node, and site.
-func New(experiment string, nodeName string) (Namer, error) {
+func New(datatype, experiment, nodeName string) (Namer, error) {
 	// Extract M-Lab machine (mlab5) and site (abc0t) names from node FQDN (mlab5.abc0t.measurement-lab.org).
 	fields := strings.SplitN(nodeName, ".", 3)
 	if len(fields) < 2 {
@@ -29,6 +30,7 @@ func New(experiment string, nodeName string) (Namer, error) {
 			fields[0], fields[1])
 	}
 	return namer{
+		datatype:   datatype,
 		experiment: experiment,
 		node:       fields[0],
 		site:       fields[1],
@@ -39,5 +41,5 @@ func New(experiment string, nodeName string) (Namer, error) {
 // filename for an uploaded tarfile in a bucket.
 func (n namer) ObjectName(subdir string, t time.Time) string {
 	timestring := t.Format("20060102T150405.000000Z")
-	return (n.experiment + "/" + subdir + "/" + timestring + "-" + n.node + "-" + n.site + "-" + n.experiment + ".tgz")
+	return path.Join(n.experiment, n.datatype, subdir, timestring+"-"+n.node+"-"+n.site+"-"+n.experiment+".tgz")
 }

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -41,5 +41,5 @@ func New(datatype, experiment, nodeName string) (Namer, error) {
 // filename for an uploaded tarfile in a bucket.
 func (n namer) ObjectName(subdir string, t time.Time) string {
 	timestring := t.Format("20060102T150405.000000Z")
-	return path.Join(n.experiment, n.datatype, subdir, timestring+"-"+n.node+"-"+n.site+"-"+n.experiment+".tgz")
+	return path.Join(n.experiment, n.datatype, subdir, timestring+"-"+n.datatype+"-"+n.node+"-"+n.site+"-"+n.experiment+".tgz")
 }

--- a/namer/namer.go
+++ b/namer/namer.go
@@ -6,11 +6,13 @@ import (
 	"path"
 	"strings"
 	"time"
+
+	"github.com/m-lab/pusher/filename"
 )
 
 // Namer creates tarfile names from timestamps.  The name does not include the bucket.
 type Namer interface {
-	ObjectName(string, time.Time) string
+	ObjectName(filename.System, time.Time) string
 }
 
 // This is a specific namer used for M-Lab experiments.
@@ -39,7 +41,7 @@ func New(datatype, experiment, nodeName string) (Namer, error) {
 
 // ObjectName returns a string (with a leading '/') representing the correct
 // filename for an uploaded tarfile in a bucket.
-func (n namer) ObjectName(subdir string, t time.Time) string {
+func (n namer) ObjectName(subdir filename.System, t time.Time) string {
 	timestring := t.Format("20060102T150405.000000Z")
-	return path.Join(n.experiment, n.datatype, subdir, timestring+"-"+n.datatype+"-"+n.node+"-"+n.site+"-"+n.experiment+".tgz")
+	return path.Join(n.experiment, n.datatype, string(subdir), timestring+"-"+n.datatype+"-"+n.node+"-"+n.site+"-"+n.experiment+".tgz")
 }

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/namer"
 )
 
@@ -29,7 +30,7 @@ func TestFilenameGeneration(t *testing.T) {
 		t.Fatal("Failed to create new namer")
 	}
 	for _, test := range tests {
-		if out := namer.ObjectName(test.dir, test.date); out != test.out {
+		if out := namer.ObjectName(filename.System(test.dir), test.date); out != test.out {
 			t.Errorf("%q != %q (input: %v, %v)", out, test.out, test.dir, test.date)
 		}
 	}

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -16,12 +16,12 @@ func TestFilenameGeneration(t *testing.T) {
 		{
 			date: time.Date(2018, 5, 6, 15, 1, 2, 44001000, time.UTC),
 			dir:  "monkey",
-			out:  "exp/summary/monkey/20180506T150102.044001Z-mlab6-lga0t-exp.tgz",
+			out:  "exp/summary/monkey/20180506T150102.044001Z-summary-mlab6-lga0t-exp.tgz",
 		},
 		{
 			date: time.Date(2008, 1, 1, 0, 0, 0, 0, time.UTC),
 			dir:  "2008/01/01",
-			out:  "exp/summary/2008/01/01/20080101T000000.000000Z-mlab6-lga0t-exp.tgz",
+			out:  "exp/summary/2008/01/01/20080101T000000.000000Z-summary-mlab6-lga0t-exp.tgz",
 		},
 	}
 	namer, err := namer.New("summary", "exp", "mlab6.lga0t")
@@ -46,7 +46,7 @@ func TestNew(t *testing.T) {
 		{
 			name:        "success",
 			nodeName:    "mlab5.abc0t.measurement-lab.org",
-			wantObjName: "fake-experiment/dat/2011/03/04/20110304T124500.000000Z-mlab5-abc0t-fake-experiment.tgz",
+			wantObjName: "fake-experiment/dat/2011/03/04/20110304T124500.000000Z-dat-mlab5-abc0t-fake-experiment.tgz",
 		},
 		{
 			name:     "failure-machine-too-short",

--- a/namer/namer_test.go
+++ b/namer/namer_test.go
@@ -16,15 +16,15 @@ func TestFilenameGeneration(t *testing.T) {
 		{
 			date: time.Date(2018, 5, 6, 15, 1, 2, 44001000, time.UTC),
 			dir:  "monkey",
-			out:  "exp/monkey/20180506T150102.044001Z-mlab6-lga0t-exp.tgz",
+			out:  "exp/summary/monkey/20180506T150102.044001Z-mlab6-lga0t-exp.tgz",
 		},
 		{
 			date: time.Date(2008, 1, 1, 0, 0, 0, 0, time.UTC),
 			dir:  "2008/01/01",
-			out:  "exp/2008/01/01/20080101T000000.000000Z-mlab6-lga0t-exp.tgz",
+			out:  "exp/summary/2008/01/01/20080101T000000.000000Z-mlab6-lga0t-exp.tgz",
 		},
 	}
-	namer, err := namer.New("exp", "mlab6.lga0t")
+	namer, err := namer.New("summary", "exp", "mlab6.lga0t")
 	if err != nil {
 		t.Fatal("Failed to create new namer")
 	}
@@ -46,7 +46,7 @@ func TestNew(t *testing.T) {
 		{
 			name:        "success",
 			nodeName:    "mlab5.abc0t.measurement-lab.org",
-			wantObjName: "fake-experiment/2011/03/04/20110304T124500.000000Z-mlab5-abc0t-fake-experiment.tgz",
+			wantObjName: "fake-experiment/dat/2011/03/04/20110304T124500.000000Z-mlab5-abc0t-fake-experiment.tgz",
 		},
 		{
 			name:     "failure-machine-too-short",
@@ -66,7 +66,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := namer.New("fake-experiment", tt.nodeName)
+			got, err := namer.New("dat", "fake-experiment", tt.nodeName)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pusher.go
+++ b/pusher.go
@@ -3,7 +3,10 @@ package main
 import (
 	"context"
 	"flag"
+	"fmt"
 	"net/http"
+	"os"
+	"path"
 	"time"
 
 	"cloud.google.com/go/storage"
@@ -23,7 +26,7 @@ import (
 var (
 	monitorAddr     = flag.String("monitoring_address", ":9000", "The address and port on which prometheus metrics should be exported.")
 	project         = flag.String("project", "mlab-sandbox", "The google cloud project")
-	directory       = flag.String("directory", "/var/spool/test", "The directory to watch for files.")
+	directory       = flag.String("directory", "/var/spool", "The directory containing one subdirectory per datatype.")
 	bucket          = flag.String("bucket", "scraper-mlab-sandbox", "The GCS bucket to upload data to")
 	experiment      = flag.String("experiment", "exp", "The name of the experiment generating the data")
 	nodeName        = flag.String("mlab_node_name", "mlab5.abc0t.measurement-lab.org", "FQDN of the M-Lab node. Used to extract machine (mlab5) and site (abc0t) names.")
@@ -42,31 +45,52 @@ func init() {
 }
 
 func main() {
+	flag.Usage = func() {
+		fmt.Fprintf(flag.CommandLine.Output(), "Usage of %s:\n", os.Args[0])
+		flag.PrintDefaults()
+		fmt.Fprintf(flag.CommandLine.Output(),
+			`
+Every flag can also be set by setting an all-caps environment variable with
+the same name as the flag. For example if "-bucket" was not on the
+commandline, the GCS bucket to use can also be set by the $BUCKET environment
+variable.
+
+All unparsed command-line arguments will be treated as independent datatypes
+for uploading to GCS. These datatypes determine the subdirectory of GCS the
+data is uploaded to, and they determine the subdirectory of /var/spool to
+watch. Best practices dictate that these names should also be the first part
+of the hostname of the machine as well as the name of the tables where this
+data arrives in BigQuery.
+`)
+	}
 	// We want to get flag values from the environment or from the command-line.
 	flag.Parse()
 	flagx.ArgsFromEnv(flag.CommandLine)
 
 	defer cancelCtx()
 
-	// Set up the upload system.
-	namer, err := namer.New(*experiment, *nodeName)
-	rtx.Must(err, "Could not create a new Namer")
-	client, err := storage.NewClient(ctx)
-	rtx.Must(err, "Could not create cloud storage client")
+	for _, datatype := range flag.Args() {
+		// Set up the upload system.
+		namer, err := namer.New(datatype, *experiment, *nodeName)
+		rtx.Must(err, "Could not create a new Namer")
+		client, err := storage.NewClient(ctx)
+		rtx.Must(err, "Could not create cloud storage client")
 
-	uploader := uploader.Create(ctx, stiface.AdaptClient(client), *bucket, namer)
+		uploader := uploader.Create(ctx, stiface.AdaptClient(client), *bucket, namer)
 
-	// Set up the file-bundling tarcache system.
-	tarCache, pusherChannel := tarcache.New(*directory, sizeThreshold, *ageThreshold, uploader)
-	go tarCache.ListenForever(ctx)
+		// Set up the file-bundling tarcache system.
+		tarCache, pusherChannel := tarcache.New(*directory, sizeThreshold, *ageThreshold, uploader)
+		go tarCache.ListenForever(ctx)
 
-	// Send all file close and file move events to the tarCache.
-	l, err := listener.Create(*directory, pusherChannel)
-	rtx.Must(err, "Could not create listener")
-	go l.ListenForever(ctx)
+		datadir := path.Join(*directory, datatype)
+		// Send all file close and file move events to the tarCache.
+		l, err := listener.Create(datadir, pusherChannel)
+		rtx.Must(err, "Could not create listener")
+		go l.ListenForever(ctx)
 
-	// Send very old or missed files to the tarCache as a cleanup precaution.
-	go finder.FindForever(ctx, *directory, *maxFileAge, pusherChannel, *cleanupInterval)
+		// Send very old or missed files to the tarCache as a cleanup precaution.
+		go finder.FindForever(ctx, datadir, *maxFileAge, pusherChannel, *cleanupInterval)
+	}
 
 	// Start up the monitoring service.
 	http.Handle("/metrics", promhttp.Handler())

--- a/pusher_integration_test.go
+++ b/pusher_integration_test.go
@@ -79,7 +79,7 @@ type fakeNamer struct {
 	name string
 }
 
-func (f fakeNamer) ObjectName(_ string, _ time.Time) string {
+func (f fakeNamer) ObjectName(_ filename.System, _ time.Time) string {
 	log.Println("Returned object name:", f.name)
 	return f.name
 }

--- a/pusher_integration_test.go
+++ b/pusher_integration_test.go
@@ -17,6 +17,7 @@ import (
 	"cloud.google.com/go/storage"
 	"github.com/m-lab/go/osx"
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/listener"
 	"github.com/m-lab/pusher/tarcache"
 	"github.com/m-lab/pusher/uploader"
@@ -78,7 +79,7 @@ type fakeNamer struct {
 	name string
 }
 
-func (f fakeNamer) ObjectName(_ string, t time.Time) string {
+func (f fakeNamer) ObjectName(_ string, _ time.Time) string {
 	log.Println("Returned object name:", f.name)
 	return f.name
 }
@@ -101,11 +102,11 @@ func TestListenerTarcacheAndUploader(t *testing.T) {
 		return
 	}
 
-	tarCache, pusherChannel := tarcache.New(tempdir, 1, 1, up)
+	tarCache, pusherChannel := tarcache.New(filename.System(tempdir), "test", 1, 1, up)
 	go tarCache.ListenForever(ctx)
 
 	// Set up the listener on the temp directory.
-	l, err := listener.Create(tempdir, pusherChannel)
+	l, err := listener.Create(filename.System(tempdir), pusherChannel)
 	rtx.Must(err, "Could not create listener")
 	go l.ListenForever(ctx)
 
@@ -215,11 +216,11 @@ func TestListenerTarcacheAndUploaderWithOneFailure(t *testing.T) {
 		return
 	}
 
-	tarCache, pusherChannel := tarcache.New(tempdir, 1, 1, up)
+	tarCache, pusherChannel := tarcache.New(filename.System(tempdir), "testdata", 1, 1, up)
 	go tarCache.ListenForever(ctx)
 
 	// Set up the listener on the temp directory.
-	l, err := listener.Create(tempdir, pusherChannel)
+	l, err := listener.Create(filename.System(tempdir), pusherChannel)
 	rtx.Must(err, "Could not create listener")
 	go l.ListenForever(ctx)
 

--- a/pusher_integration_test.go
+++ b/pusher_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"flag"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -31,6 +32,7 @@ func TestMainAndPrometheusMetrics(t *testing.T) {
 		t.Error(err)
 		return
 	}
+	rtx.Must(os.Mkdir(tempdir+"/testdata", 0777), "Could not create dir.")
 	// Set up the environment variables.
 	type TempEnvVar struct {
 		name, value string
@@ -67,7 +69,9 @@ func TestMainAndPrometheusMetrics(t *testing.T) {
 		}
 		cancelCtx()
 	}()
+	os.Args = append(os.Args, "testdata") // Monitor the testdata directory inside of tempdir.
 	main()
+	flag.Usage() // As an extra test, make sure our custom usage message doesn't crash everything.
 }
 
 type fakeNamer struct {

--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -1,160 +1,25 @@
-package tarcache
+package tarcache_test
 
 import (
-	"bytes"
 	"context"
 	"crypto/rand"
-	"errors"
-	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
-	"os/exec"
-	"regexp"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/m-lab/go/bytecount"
 	"github.com/m-lab/go/rtx"
-	"github.com/m-lab/pusher/tarfile"
+	"github.com/m-lab/pusher/tarcache"
 )
 
 type fakeUploader struct {
-	contents         []byte
-	calls            int
-	requestedRetries int
-	expectedDir      string
+	calls int
 }
 
 func (f *fakeUploader) Upload(dir string, contents []byte) error {
-	if f.expectedDir != "" && dir != f.expectedDir {
-		log.Fatalf("Upload to unexpected directory: %v != %v\n", dir, f.expectedDir)
-	}
-	f.contents = contents
 	f.calls++
-	if f.requestedRetries > 0 {
-		f.requestedRetries--
-		return errors.New("A fake error to trigger retry logic")
-	}
 	return nil
-}
-
-type FileInTarfile struct {
-	name string
-	size int
-}
-
-// verifyTarfileContents checks that the referenced tarfile actually contains
-// each file in contents.  The filenames should not contain characters which
-// have a special meaning in a regular expression context.
-func verifyTarfileContents(t *testing.T, tarfile string, contents []FileInTarfile) {
-	// Get the table of files in the tarfile.
-	cmd := exec.Command("tar", "tvfz", tarfile)
-	var out bytes.Buffer
-	cmd.Stdout = &out
-	err := cmd.Run()
-	if err != nil {
-		t.Fatalf("tar command failed: %q", err)
-	}
-	// All files are unseen initially.
-	seenFile := make([]bool, len(contents))
-	// For each line in the table of output, check it against each file.
-	for _, lineString := range strings.Split(string(out.Bytes()), "\n") {
-		if lineString == "" {
-			continue
-		}
-		line := []byte(lineString)
-		matched := false
-		for i, f := range contents {
-			re := fmt.Sprintf(" %d .* %s$", f.size, f.name)
-			if match, err := regexp.Match(re, line); match && err == nil {
-				matched = true
-				seenFile[i] = true
-			}
-		}
-		// Every line should match some file, or else there are random
-		// extra files present.
-		if !matched {
-			t.Errorf("Bad line: %q", line)
-		}
-	}
-	// If any file is unseen, report an error.
-	for i, seen := range seenFile {
-		if !seen {
-			t.Errorf("Did not find file %s in the output of tar", contents[i].name)
-		}
-	}
-}
-
-// A whitebox test that verifies that the cache contents are built up gradually.
-func TestAdd(t *testing.T) {
-	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestAdd")
-	defer os.RemoveAll(tempdir)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	oldDir, err := os.Getwd()
-	rtx.Must(err, "Could not get working directory")
-	rtx.Must(os.Chdir(tempdir), "Could not chdir to the tempdir")
-	defer os.Chdir(oldDir)
-
-	// Make the data files, one small and one big.
-	os.MkdirAll("a/b", 0700)
-	ioutil.WriteFile("a/b/tinyfile", []byte("abcdefgh"), os.FileMode(0666))
-	bigcontents := make([]byte, 2000)
-	rand.Read(bigcontents)
-	ioutil.WriteFile("a/b/bigfile", bigcontents, os.FileMode(0666))
-
-	uploader := fakeUploader{
-		requestedRetries: 1,
-		expectedDir:      "a/b",
-	}
-	// Ignore the returned channel - this is a whitebox test.
-	tarCache, _ := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
-	if len(tarCache.currentTarfile) != 0 {
-		t.Errorf("The file list should be of zero length and is not (%d != 0)", len(tarCache.currentTarfile))
-	}
-	// Add the tiny file, which should not trigger an upload.
-	tinyFile := SystemFilename(tempdir + "/a/b/tinyfile")
-	tarCache.add(tinyFile)
-	// Add the tiny file a second time, which should not do anything at all.
-	tarCache.add(tinyFile)
-	if len(tarCache.currentTarfile) == 0 {
-		t.Errorf("The file should be of nonzero length and is not (%d == 0)", len(tarCache.currentTarfile))
-	}
-	if uploader.calls != 0 {
-		t.Error("uploader.calls should be zero ", uploader.calls)
-	}
-	// Add the big file, which should trigger an upload and file deletion.
-	bigFile := SystemFilename(tempdir + "/a/b/bigfile")
-	tarCache.add(bigFile)
-	if uploader.calls == 0 {
-		t.Error("uploader.calls should be >0 ")
-	}
-	if contents, err := ioutil.ReadFile(tempdir + "/a/b/tinyfile"); err == nil {
-		t.Errorf("tinyfile was not deleted, but should have been - contents are %q", string(contents))
-	}
-	// Ensure that the uploaded tarfile can be opened by tar and contains files of the correct size.
-	ioutil.WriteFile("tarfile.tgz", uploader.contents, os.FileMode(0666))
-	verifyTarfileContents(t, "tarfile.tgz",
-		[]FileInTarfile{
-			{name: "a/b/tinyfile", size: 8},
-			{name: "a/b/bigfile", size: 2000}})
-	// Now add one more file to make sure that the cache still works after upload.
-	ioutil.WriteFile(tempdir+"/tiny2", []byte("12345678"), os.FileMode(0666))
-	tiny2File := SystemFilename(tempdir + "/tiny2")
-	if len(tarCache.currentTarfile) != 0 {
-		t.Errorf("Failed to clear the cache after upload (%v)", len(tarCache.currentTarfile))
-		for k := range tarCache.currentTarfile {
-			t.Errorf("%q should not be in the cache", k)
-		}
-	}
-	tarCache.add(tiny2File)
-	if len(tarCache.currentTarfile) != 1 {
-		t.Error("Failed to add the new file after upload")
-	}
 }
 
 func TestTimer(t *testing.T) {
@@ -178,10 +43,10 @@ func TestTimer(t *testing.T) {
 	ioutil.WriteFile("c/d/tinyfile", []byte("abcdefgh"), os.FileMode(0666))
 
 	uploader := &fakeUploader{}
-	tarCache, channel := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), uploader)
+	tarCache, channel := tarcache.New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), uploader)
 	// Add the small file, which should not trigger an upload.
-	tinyFile := SystemFilename("a/b/tinyfile")
-	otherTinyFile := SystemFilename("c/d/tinyfile")
+	tinyFile := tarcache.SystemFilename("a/b/tinyfile")
+	otherTinyFile := tarcache.SystemFilename("c/d/tinyfile")
 	ctx := context.Background()
 	go tarCache.ListenForever(ctx)
 	channel <- tinyFile
@@ -205,7 +70,7 @@ func TestTimer(t *testing.T) {
 	}
 	// Create a tiny file and add it.
 	ioutil.WriteFile("tiny2", []byte("12345678"), os.FileMode(0666))
-	tiny2File := SystemFilename("tiny2")
+	tiny2File := tarcache.SystemFilename("tiny2")
 	channel <- tiny2File
 	if uploader.calls != 0 {
 		t.Error("uploader.calls should be zero ", uploader.calls)
@@ -219,7 +84,7 @@ func TestTimer(t *testing.T) {
 
 func TestContextCancellation(t *testing.T) {
 	uploader := fakeUploader{}
-	tarCache, _ := New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
+	tarCache, _ := tarcache.New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		time.Sleep(100 * time.Millisecond)
@@ -231,7 +96,7 @@ func TestContextCancellation(t *testing.T) {
 
 func TestChannelCloseCancellation(t *testing.T) {
 	uploader := fakeUploader{}
-	tarCache, inputChannel := New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
+	tarCache, inputChannel := tarcache.New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
 	ctx := context.Background()
 	go func() {
 		time.Sleep(100 * time.Millisecond)
@@ -239,50 +104,4 @@ func TestChannelCloseCancellation(t *testing.T) {
 	}()
 	// If this doesn't actually listen forever, then this test is a success.
 	tarCache.ListenForever(ctx)
-}
-
-func TestEmptyUpload(t *testing.T) {
-	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestEmptyUpload")
-	defer os.RemoveAll(tempdir)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	uploader := fakeUploader{expectedDir: tempdir}
-	// Ignore the returned channel - this is a whitebox test.
-	tarCache, _ := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
-	tarCache.currentTarfile[tempdir] = tarfile.New(tempdir, "")
-	tarCache.uploadAndDelete("this does not exist")
-	tarCache.uploadAndDelete(tempdir)
-	if uploader.calls != 0 {
-		t.Error("uploader.calls should be zero ", uploader.calls)
-	}
-
-	ioutil.WriteFile(tempdir+"/tinyfile", []byte("abcdefgh"), os.FileMode(0666))
-	// Add the small file, which should not trigger an upload.
-	tarCache.add(SystemFilename(tempdir + "/tinyfile"))
-
-	if err = os.Remove(tempdir + "/tinyfile"); err != nil {
-		t.Errorf("Could not remove the tinyfile: %v", err)
-	}
-
-	// This should not crash, even though we removed the tinyfile out from underneath the uploader.
-	tarCache.uploadAndDelete(tempdir)
-}
-
-func TestUnreadableFile(t *testing.T) {
-	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestUnreadableFile")
-	defer os.RemoveAll(tempdir)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-	uploader := fakeUploader{}
-	// Ignore the returned channel - this is a whitebox test.
-	tarCache, _ := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
-	// This should not crash, even though the file does not exist.
-	tarCache.add(SystemFilename(tempdir + "/dne"))
-	if tf, ok := tarCache.currentTarfile[tempdir]; ok && tf.Size() != 0 {
-		t.Error("We added a nonexistent file to the tarCache.")
-	}
 }

--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -251,7 +251,7 @@ func TestEmptyUpload(t *testing.T) {
 	uploader := fakeUploader{expectedDir: tempdir}
 	// Ignore the returned channel - this is a whitebox test.
 	tarCache, _ := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
-	tarCache.currentTarfile[tempdir] = tarfile.New(tempdir)
+	tarCache.currentTarfile[tempdir] = tarfile.New(tempdir, "")
 	tarCache.uploadAndDelete("this does not exist")
 	tarCache.uploadAndDelete(tempdir)
 	if uploader.calls != 0 {

--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/m-lab/go/bytecount"
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/tarcache"
 )
 
@@ -43,10 +44,10 @@ func TestTimer(t *testing.T) {
 	ioutil.WriteFile("c/d/tinyfile", []byte("abcdefgh"), os.FileMode(0666))
 
 	uploader := &fakeUploader{}
-	tarCache, channel := tarcache.New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), uploader)
+	tarCache, channel := tarcache.New(filename.System(tempdir), "test", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), uploader)
 	// Add the small file, which should not trigger an upload.
-	tinyFile := tarcache.SystemFilename("a/b/tinyfile")
-	otherTinyFile := tarcache.SystemFilename("c/d/tinyfile")
+	tinyFile := filename.System("a/b/tinyfile")
+	otherTinyFile := filename.System("c/d/tinyfile")
 	ctx := context.Background()
 	go tarCache.ListenForever(ctx)
 	channel <- tinyFile
@@ -70,7 +71,7 @@ func TestTimer(t *testing.T) {
 	}
 	// Create a tiny file and add it.
 	ioutil.WriteFile("tiny2", []byte("12345678"), os.FileMode(0666))
-	tiny2File := tarcache.SystemFilename("tiny2")
+	tiny2File := filename.System("tiny2")
 	channel <- tiny2File
 	if uploader.calls != 0 {
 		t.Error("uploader.calls should be zero ", uploader.calls)
@@ -84,7 +85,7 @@ func TestTimer(t *testing.T) {
 
 func TestContextCancellation(t *testing.T) {
 	uploader := fakeUploader{}
-	tarCache, _ := tarcache.New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
+	tarCache, _ := tarcache.New(filename.System("/tmp"), "test", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		time.Sleep(100 * time.Millisecond)
@@ -96,7 +97,7 @@ func TestContextCancellation(t *testing.T) {
 
 func TestChannelCloseCancellation(t *testing.T) {
 	uploader := fakeUploader{}
-	tarCache, inputChannel := tarcache.New("/tmp", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
+	tarCache, inputChannel := tarcache.New(filename.System("/tmp"), "test", bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(100*time.Millisecond), &uploader)
 	ctx := context.Background()
 	go func() {
 		time.Sleep(100 * time.Millisecond)

--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -18,7 +18,7 @@ type fakeUploader struct {
 	calls int
 }
 
-func (f *fakeUploader) Upload(dir string, contents []byte) error {
+func (f *fakeUploader) Upload(_ filename.System, _ []byte) error {
 	f.calls++
 	return nil
 }

--- a/tarcache/whitebox_test.go
+++ b/tarcache/whitebox_test.go
@@ -69,8 +69,8 @@ type fakeUploader struct {
 	expectedDir      string
 }
 
-func (f *fakeUploader) Upload(dir string, contents []byte) error {
-	if f.expectedDir != "" && dir != f.expectedDir {
+func (f *fakeUploader) Upload(dir filename.System, contents []byte) error {
+	if f.expectedDir != "" && string(dir) != f.expectedDir {
 		log.Fatalf("Upload to unexpected directory: %v != %v\n", dir, f.expectedDir)
 	}
 	f.contents = contents

--- a/tarcache/whitebox_test.go
+++ b/tarcache/whitebox_test.go
@@ -1,0 +1,203 @@
+package tarcache
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m-lab/go/bytecount"
+	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/pusher/tarfile"
+)
+
+// verifyTarfileContents checks that the referenced tarfile actually contains
+// each file in contents.  The filenames should not contain characters which
+// have a special meaning in a regular expression context.
+func verifyTarfileContents(t *testing.T, tarfile string, contents []FileInTarfile) {
+	// Get the table of files in the tarfile.
+	cmd := exec.Command("tar", "tvfz", tarfile)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		t.Fatalf("tar command failed: %q", err)
+	}
+	// All files are unseen initially.
+	seenFile := make([]bool, len(contents))
+	// For each line in the table of output, check it against each file.
+	for _, lineString := range strings.Split(string(out.Bytes()), "\n") {
+		if lineString == "" {
+			continue
+		}
+		line := []byte(lineString)
+		matched := false
+		for i, f := range contents {
+			re := fmt.Sprintf(" %d .* %s$", f.size, f.name)
+			if match, err := regexp.Match(re, line); match && err == nil {
+				matched = true
+				seenFile[i] = true
+			}
+		}
+		// Every line should match some file, or else there are random
+		// extra files present.
+		if !matched {
+			t.Errorf("Bad line: %q", line)
+		}
+	}
+	// If any file is unseen, report an error.
+	for i, seen := range seenFile {
+		if !seen {
+			t.Errorf("Did not find file %s in the output of tar", contents[i].name)
+		}
+	}
+}
+
+type fakeUploader struct {
+	contents         []byte
+	calls            int
+	requestedRetries int
+	expectedDir      string
+}
+
+func (f *fakeUploader) Upload(dir string, contents []byte) error {
+	if f.expectedDir != "" && dir != f.expectedDir {
+		log.Fatalf("Upload to unexpected directory: %v != %v\n", dir, f.expectedDir)
+	}
+	f.contents = contents
+	f.calls++
+	if f.requestedRetries > 0 {
+		f.requestedRetries--
+		return errors.New("A fake error to trigger retry logic")
+	}
+	return nil
+}
+
+type FileInTarfile struct {
+	name string
+	size int
+}
+
+func TestEmptyUpload(t *testing.T) {
+	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestEmptyUpload")
+	defer os.RemoveAll(tempdir)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	uploader := fakeUploader{expectedDir: tempdir}
+	// Ignore the returned channel - this is a whitebox test.
+	tarCache, _ := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
+	tarCache.currentTarfile[tempdir] = tarfile.New(tempdir, "")
+	tarCache.uploadAndDelete("this does not exist")
+	tarCache.uploadAndDelete(tempdir)
+	if uploader.calls != 0 {
+		t.Error("uploader.calls should be zero ", uploader.calls)
+	}
+
+	ioutil.WriteFile(tempdir+"/tinyfile", []byte("abcdefgh"), os.FileMode(0666))
+	// Add the small file, which should not trigger an upload.
+	tarCache.add(SystemFilename(tempdir + "/tinyfile"))
+
+	if err = os.Remove(tempdir + "/tinyfile"); err != nil {
+		t.Errorf("Could not remove the tinyfile: %v", err)
+	}
+
+	// This should not crash, even though we removed the tinyfile out from underneath the uploader.
+	tarCache.uploadAndDelete(tempdir)
+}
+
+func TestUnreadableFile(t *testing.T) {
+	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestUnreadableFile")
+	defer os.RemoveAll(tempdir)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	uploader := fakeUploader{}
+	// Ignore the returned channel - this is a whitebox test.
+	tarCache, _ := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
+	// This should not crash, even though the file does not exist.
+	tarCache.add(SystemFilename(tempdir + "/dne"))
+	if tf, ok := tarCache.currentTarfile[tempdir]; ok && tf.Size() != 0 {
+		t.Error("We added a nonexistent file to the tarCache.")
+	}
+}
+
+// A whitebox test that verifies that the cache contents are built up gradually.
+func TestAdd(t *testing.T) {
+	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestAdd")
+	defer os.RemoveAll(tempdir)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	oldDir, err := os.Getwd()
+	rtx.Must(err, "Could not get working directory")
+	rtx.Must(os.Chdir(tempdir), "Could not chdir to the tempdir")
+	defer os.Chdir(oldDir)
+
+	// Make the data files, one small and one big.
+	os.MkdirAll("a/b", 0700)
+	ioutil.WriteFile("a/b/tinyfile", []byte("abcdefgh"), os.FileMode(0666))
+	bigcontents := make([]byte, 2000)
+	rand.Read(bigcontents)
+	ioutil.WriteFile("a/b/bigfile", bigcontents, os.FileMode(0666))
+
+	uploader := fakeUploader{
+		requestedRetries: 1,
+		expectedDir:      "a/b",
+	}
+	// Ignore the returned channel - this is a whitebox test.
+	tarCache, _ := New(tempdir, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
+	if len(tarCache.currentTarfile) != 0 {
+		t.Errorf("The file list should be of zero length and is not (%d != 0)", len(tarCache.currentTarfile))
+	}
+	// Add the tiny file, which should not trigger an upload.
+	tinyFile := SystemFilename(tempdir + "/a/b/tinyfile")
+	tarCache.add(tinyFile)
+	// Add the tiny file a second time, which should not do anything at all.
+	tarCache.add(tinyFile)
+	if len(tarCache.currentTarfile) == 0 {
+		t.Errorf("The file should be of nonzero length and is not (%d == 0)", len(tarCache.currentTarfile))
+	}
+	if uploader.calls != 0 {
+		t.Error("uploader.calls should be zero ", uploader.calls)
+	}
+	// Add the big file, which should trigger an upload and file deletion.
+	bigFile := SystemFilename(tempdir + "/a/b/bigfile")
+	tarCache.add(bigFile)
+	if uploader.calls == 0 {
+		t.Error("uploader.calls should be >0 ")
+	}
+	if contents, err := ioutil.ReadFile(tempdir + "/a/b/tinyfile"); err == nil {
+		t.Errorf("tinyfile was not deleted, but should have been - contents are %q", string(contents))
+	}
+	// Ensure that the uploaded tarfile can be opened by tar and contains files of the correct size.
+	ioutil.WriteFile("tarfile.tgz", uploader.contents, os.FileMode(0666))
+	verifyTarfileContents(t, "tarfile.tgz",
+		[]FileInTarfile{
+			{name: "a/b/tinyfile", size: 8},
+			{name: "a/b/bigfile", size: 2000}})
+	// Now add one more file to make sure that the cache still works after upload.
+	ioutil.WriteFile(tempdir+"/tiny2", []byte("12345678"), os.FileMode(0666))
+	tiny2File := SystemFilename(tempdir + "/tiny2")
+	if len(tarCache.currentTarfile) != 0 {
+		t.Errorf("Failed to clear the cache after upload (%v)", len(tarCache.currentTarfile))
+		for k := range tarCache.currentTarfile {
+			t.Errorf("%q should not be in the cache", k)
+		}
+	}
+	tarCache.add(tiny2File)
+	if len(tarCache.currentTarfile) != 1 {
+		t.Error("Failed to add the new file after upload")
+	}
+}

--- a/tarfile/tarfile.go
+++ b/tarfile/tarfile.go
@@ -22,65 +22,81 @@ import (
 )
 
 var (
-	pusherTarfilesCreated = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_tarfiles_created_total",
-		Help: "The number of tarfiles the pusher has created",
-	})
-	pusherTarfilesUploaded = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_tarfiles_successful_uploads_total",
-		Help: "The number of tarfiles the pusher has uploaded",
-	})
-	pusherFilesPerTarfile = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pusher_files_per_tarfile",
-		Help:    "The number of files in each tarfile the pusher has uploaded",
-		Buckets: []float64{1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000},
-	})
-	pusherBytesPerTarfile = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pusher_bytes_per_tarfile",
-		Help:    "The number of bytes in each tarfile the pusher has uploaded",
-		Buckets: []float64{1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9},
-	})
-	pusherBytesPerFile = prometheus.NewHistogram(prometheus.HistogramOpts{
-		Name:    "pusher_bytes_per_file",
-		Help:    "The number of bytes in each file the pusher has uploaded",
-		Buckets: []float64{1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9},
-	})
-	pusherTarfileDuplicateFiles = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_tarfiles_duplicates_total",
-		Help: "The number of times we attempted to add a file twice to the same tarfile",
-	})
-	pusherFileReadErrors = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_file_read_errors_total",
-		Help: "The number of times we could not read or stat a file that we were trying to add to the tarfile",
-	})
-	pusherFilesAdded = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_files_added_total",
-		Help: "The number of files we have added to a tarfile",
-	})
-	pusherFilesRemoved = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_files_removed_total",
-		Help: "The number of files we have removed from the disk after upload",
-	})
-	pusherFileRemoveErrors = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_file_remove_errors_total",
-		Help: "The number of times the os.Remove call failed",
-	})
-	pusherEmptyUploads = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_empty_uploads_total",
-		Help: "The number of times we tried to upload a tarfile with nothing in it",
-	})
-	pusherCurrentTarfileFilesCreated = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "pusher_current_tarfile_files",
-		Help: "The number of files in the current tarfile",
-	})
-	pusherTotalTarfileSize = prometheus.NewCounter(prometheus.CounterOpts{
-		Name: "pusher_tarfile_size_bytes_total",
-		Help: "The number of bytes we've ever put in a tarfile",
-	})
-	pusherSuccessTimestamp = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "pusher_success_timestamp",
-		Help: "The unix timestamp of the most recent pusher success",
-	})
+	pusherTarfilesCreated = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_tarfiles_created_total",
+			Help: "The number of tarfiles the pusher has created",
+		},
+		[]string{"dir"})
+	pusherTarfilesUploaded = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_tarfiles_successful_uploads_total",
+			Help: "The number of tarfiles the pusher has uploaded",
+		},
+		[]string{"dir"})
+	pusherFilesPerTarfile = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "pusher_files_per_tarfile",
+			Help:    "The number of files in each tarfile the pusher has uploaded",
+			Buckets: []float64{1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000},
+		},
+		[]string{"dir"})
+	pusherBytesPerTarfile = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "pusher_bytes_per_tarfile",
+			Help:    "The number of bytes in each tarfile the pusher has uploaded",
+			Buckets: []float64{1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9},
+		},
+		[]string{"dir"})
+	pusherBytesPerFile = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "pusher_bytes_per_file",
+			Help:    "The number of bytes in each file the pusher has uploaded",
+			Buckets: []float64{1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9},
+		},
+		[]string{"dir"})
+	pusherTarfileDuplicateFiles = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_tarfiles_duplicates_total",
+			Help: "The number of times we attempted to add a file twice to the same tarfile",
+		},
+		[]string{"dir"})
+	pusherFileReadErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_file_read_errors_total",
+			Help: "The number of times we could not read or stat a file that we were trying to add to the tarfile",
+		},
+		[]string{"dir"})
+	pusherFilesAdded = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_files_added_total",
+			Help: "The number of files we have added to a tarfile",
+		},
+		[]string{"dir"})
+	pusherFilesRemoved = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_files_removed_total",
+			Help: "The number of files we have removed from the disk after upload",
+		},
+		[]string{"dir"})
+	pusherFileRemoveErrors = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_file_remove_errors_total",
+			Help: "The number of times the os.Remove call failed",
+		},
+		[]string{"dir"})
+	pusherEmptyUploads = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "pusher_empty_uploads_total",
+			Help: "The number of times we tried to upload a tarfile with nothing in it",
+		},
+		[]string{"dir"})
+	pusherSuccessTimestamp = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "pusher_success_timestamp",
+			Help: "The unix timestamp of the most recent pusher success",
+		},
+		[]string{"dir"})
 )
 
 func init() {
@@ -95,8 +111,6 @@ func init() {
 	prometheus.MustRegister(pusherFilesRemoved)
 	prometheus.MustRegister(pusherFileRemoveErrors)
 	prometheus.MustRegister(pusherEmptyUploads)
-	prometheus.MustRegister(pusherCurrentTarfileFilesCreated)
-	prometheus.MustRegister(pusherTotalTarfileSize)
 	prometheus.MustRegister(pusherSuccessTimestamp)
 }
 
@@ -154,6 +168,7 @@ type tarfile struct {
 	tarWriter  *tar.Writer
 	gzipWriter *gzip.Writer
 	subdir     string
+	root       string
 }
 
 // Tarfile represents all the capabilities of a tarfile.  You can add files to it, upload it, and check its size.
@@ -164,8 +179,8 @@ type Tarfile interface {
 }
 
 // New creates a new tarfile to hold the contents of a particular subdirectory.
-func New(dir string) Tarfile {
-	pusherTarfilesCreated.Inc()
+func New(root, subdir string) Tarfile {
+	pusherTarfilesCreated.WithLabelValues(root).Inc()
 	// TODO: profile and determine if preallocation is a good idea.
 	buffer := &bytes.Buffer{}
 	gzipWriter := gzip.NewWriter(buffer)
@@ -175,7 +190,8 @@ func New(dir string) Tarfile {
 		tarWriter:  tarWriter,
 		gzipWriter: gzipWriter,
 		memberSet:  make(map[InternalFilename]struct{}),
-		subdir:     dir,
+		subdir:     subdir,
+		root:       root,
 	}
 }
 
@@ -191,18 +207,18 @@ type osFile interface {
 // first file added.
 func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactory func(string) *time.Timer) {
 	if _, present := t.memberSet[cleanedFilename]; present {
-		pusherTarfileDuplicateFiles.Inc()
+		pusherTarfileDuplicateFiles.WithLabelValues(t.root).Inc()
 		log.Printf("Not adding %q to the tarfile a second time.\n", cleanedFilename)
 		return
 	}
 	fstat, err := file.Stat()
 	if err != nil {
-		pusherFileReadErrors.Inc()
+		pusherFileReadErrors.WithLabelValues(t.root).Inc()
 		log.Printf("Could not stat %s (error: %q)\n", cleanedFilename, err)
 		return
 	}
 	size := fstat.Size()
-	pusherBytesPerFile.Observe(float64(size))
+	pusherBytesPerFile.WithLabelValues(t.root).Observe(float64(size))
 	// We read the file into memory instead of using io.Copy because if the use of
 	// io.Copy goes wrong, then we have to make the error fatal (because the
 	// already-written tarfile headers are now wrong), while the reading of disk
@@ -215,12 +231,12 @@ func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactor
 	// `tarWriter.Write(contents)` line with `io.Copy(tarWriter, file)`.
 	contents := make([]byte, size)
 	if n, err := file.Read(contents); int64(n) != size || err != nil {
-		pusherFileReadErrors.Inc()
+		pusherFileReadErrors.WithLabelValues(t.root).Inc()
 		log.Printf("Could not read %s (error: %q)\n", cleanedFilename, err)
 		return
 	}
 	if n, err := file.Read(make([]byte, 1)); n != 0 || err != io.EOF {
-		pusherFileReadErrors.Inc()
+		pusherFileReadErrors.WithLabelValues(t.root).Inc()
 		log.Printf("Could not after reading %d bytes, %s was not at EOF (error: %q)\n", size, cleanedFilename, err)
 		return
 	}
@@ -244,7 +260,7 @@ func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactor
 	if len(t.members) == 0 {
 		t.timeout = timerFactory(t.subdir)
 	}
-	pusherFilesAdded.Inc()
+	pusherFilesAdded.WithLabelValues(t.root).Inc()
 	t.members = append(t.members, file)
 	t.memberSet[cleanedFilename] = struct{}{}
 }
@@ -254,8 +270,8 @@ func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactor
 // method will keep trying until the upload succeeds.
 func (t *tarfile) UploadAndDelete(uploader uploader.Uploader) {
 	if len(t.members) == 0 {
-		pusherEmptyUploads.Inc()
-		pusherSuccessTimestamp.SetToCurrentTime()
+		pusherEmptyUploads.WithLabelValues(t.root).Inc()
+		pusherSuccessTimestamp.WithLabelValues(t.root).SetToCurrentTime()
 		log.Println("uploadAndDelete called on an empty tarfile.")
 		return
 	}
@@ -264,8 +280,8 @@ func (t *tarfile) UploadAndDelete(uploader uploader.Uploader) {
 	}
 	t.tarWriter.Close()
 	t.gzipWriter.Close()
-	pusherFilesPerTarfile.Observe(float64(len(t.members)))
-	pusherBytesPerTarfile.Observe(float64(t.contents.Len()))
+	pusherFilesPerTarfile.WithLabelValues(t.root).Observe(float64(len(t.members)))
+	pusherBytesPerTarfile.WithLabelValues(t.root).Observe(float64(t.contents.Len()))
 	bytes := t.contents.Bytes()
 	// Try to upload until the upload succeeds.
 	backoff.Retry(
@@ -276,17 +292,17 @@ func (t *tarfile) UploadAndDelete(uploader uploader.Uploader) {
 		time.Duration(5)*time.Minute,
 		"upload",
 	)
-	pusherTarfilesUploaded.Inc()
-	pusherSuccessTimestamp.SetToCurrentTime()
+	pusherTarfilesUploaded.WithLabelValues(t.root).Inc()
+	pusherSuccessTimestamp.WithLabelValues(t.root).SetToCurrentTime()
 	for _, file := range t.members {
 		// If the file can't be removed, then it either was already removed or the
 		// remove call failed for some unknown reason (permissions, maybe?). If the
 		// file still exists after this attempted remove, then it should eventually
 		// get picked up by the finder.
 		if err := os.Remove(file.Name()); err == nil {
-			pusherFilesRemoved.Inc()
+			pusherFilesRemoved.WithLabelValues(t.root).Inc()
 		} else {
-			pusherFileRemoveErrors.Inc()
+			pusherFileRemoveErrors.WithLabelValues(t.root).Inc()
 			log.Printf("Failed to remove %v (error: %q)\n", file, err)
 		}
 	}

--- a/tarfile/tarfile.go
+++ b/tarfile/tarfile.go
@@ -238,7 +238,7 @@ func (t *tarfile) UploadAndDelete(uploader uploader.Uploader) {
 	// Try to upload until the upload succeeds.
 	backoff.Retry(
 		func() error {
-			return uploader.Upload(string(t.subdir), bytes)
+			return uploader.Upload(t.subdir, bytes)
 		},
 		time.Duration(100)*time.Millisecond,
 		time.Duration(5)*time.Minute,

--- a/tarfile/tarfile.go
+++ b/tarfile/tarfile.go
@@ -4,19 +4,16 @@ import (
 	"archive/tar"
 	"bytes"
 	"compress/gzip"
-	"fmt"
 	"io"
 	"log"
 	"os"
-	"path"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/m-lab/go/bytecount"
 
 	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/pusher/backoff"
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/uploader"
 	"github.com/prometheus/client_golang/prometheus"
 )
@@ -27,76 +24,76 @@ var (
 			Name: "pusher_tarfiles_created_total",
 			Help: "The number of tarfiles the pusher has created",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherTarfilesUploaded = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "pusher_tarfiles_successful_uploads_total",
 			Help: "The number of tarfiles the pusher has uploaded",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherFilesPerTarfile = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "pusher_files_per_tarfile",
 			Help:    "The number of files in each tarfile the pusher has uploaded",
 			Buckets: []float64{1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000},
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherBytesPerTarfile = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "pusher_bytes_per_tarfile",
 			Help:    "The number of bytes in each tarfile the pusher has uploaded",
 			Buckets: []float64{1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9},
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherBytesPerFile = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "pusher_bytes_per_file",
 			Help:    "The number of bytes in each file the pusher has uploaded",
 			Buckets: []float64{1e1, 1e2, 1e3, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9},
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherTarfileDuplicateFiles = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "pusher_tarfiles_duplicates_total",
 			Help: "The number of times we attempted to add a file twice to the same tarfile",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherFileReadErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "pusher_file_read_errors_total",
 			Help: "The number of times we could not read or stat a file that we were trying to add to the tarfile",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherFilesAdded = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "pusher_files_added_total",
 			Help: "The number of files we have added to a tarfile",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherFilesRemoved = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "pusher_files_removed_total",
 			Help: "The number of files we have removed from the disk after upload",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherFileRemoveErrors = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "pusher_file_remove_errors_total",
 			Help: "The number of times the os.Remove call failed",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherEmptyUploads = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "pusher_empty_uploads_total",
 			Help: "The number of times we tried to upload a tarfile with nothing in it",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 	pusherSuccessTimestamp = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "pusher_success_timestamp",
 			Help: "The unix timestamp of the most recent pusher success",
 		},
-		[]string{"dir"})
+		[]string{"datatype"})
 )
 
 func init() {
@@ -114,73 +111,28 @@ func init() {
 	prometheus.MustRegister(pusherSuccessTimestamp)
 }
 
-// InternalFilename is the pathname of a data file inside of the tarfile.
-type InternalFilename string
-
-// Subdir returns the subdirectory of the LocalDataFile, up to 3 levels deep. It
-// is only guaranteed to work right on relative path names, suitable for
-// inclusion in tarfiles.
-func (l InternalFilename) Subdir() string {
-	dirs := strings.Split(string(l), "/")
-	if len(dirs) <= 1 {
-		log.Printf("File handed to the tarcache is not in a subdirectory: %v is not split by /", l)
-		return ""
-	}
-	k := len(dirs) - 1
-	if k > 3 {
-		k = 3
-	}
-	return strings.Join(dirs[:k], "/")
-}
-
-// Lint returns nil if the file has a normal name, and an explanatory error
-// about why the name is strange otherwise.
-func (l InternalFilename) Lint() error {
-	name := string(l)
-	cleaned := path.Clean(name)
-	if cleaned != name {
-		return fmt.Errorf("The cleaned up path %q did not match the name of the passed-in file %q", cleaned, name)
-	}
-	d, f := path.Split(name)
-	if strings.HasPrefix(f, ".") {
-		return fmt.Errorf("Hidden file detected: %q", name)
-	}
-	if strings.Contains(name, "..") {
-		return fmt.Errorf("Too many dots in %v", name)
-	}
-	invalidChars := regexp.MustCompile(`[^a-zA-Z0-9/:._-]`)
-	if invalidChars.MatchString(name) {
-		return fmt.Errorf("Strange characters detected in the filename %q", name)
-	}
-	recommendedFormat := regexp.MustCompile(`^[a-zA-Z0-9_-]+/20[0-9][0-9]/[0-9]{2}/[0-9]{2}`)
-	if !recommendedFormat.MatchString(d) {
-		return fmt.Errorf("Directory structure does not mirror our best practices for file %v", name)
-	}
-	return nil
-}
-
 // A tarfile represents a single tar file containing data for upload
 type tarfile struct {
 	timeout    *time.Timer
 	members    []osFile
-	memberSet  map[InternalFilename]struct{}
+	memberSet  map[filename.Internal]struct{}
 	contents   *bytes.Buffer
 	tarWriter  *tar.Writer
 	gzipWriter *gzip.Writer
-	subdir     string
-	root       string
+	subdir     filename.System
+	datatype   string
 }
 
 // Tarfile represents all the capabilities of a tarfile.  You can add files to it, upload it, and check its size.
 type Tarfile interface {
-	Add(InternalFilename, osFile, func(string) *time.Timer)
+	Add(filename.Internal, osFile, func(string) *time.Timer)
 	UploadAndDelete(uploader uploader.Uploader)
 	Size() bytecount.ByteCount
 }
 
 // New creates a new tarfile to hold the contents of a particular subdirectory.
-func New(root, subdir string) Tarfile {
-	pusherTarfilesCreated.WithLabelValues(root).Inc()
+func New(subdir filename.System, datatype string) Tarfile {
+	pusherTarfilesCreated.WithLabelValues(datatype).Inc()
 	// TODO: profile and determine if preallocation is a good idea.
 	buffer := &bytes.Buffer{}
 	gzipWriter := gzip.NewWriter(buffer)
@@ -189,9 +141,9 @@ func New(root, subdir string) Tarfile {
 		contents:   buffer,
 		tarWriter:  tarWriter,
 		gzipWriter: gzipWriter,
-		memberSet:  make(map[InternalFilename]struct{}),
+		memberSet:  make(map[filename.Internal]struct{}),
 		subdir:     subdir,
-		root:       root,
+		datatype:   datatype,
 	}
 }
 
@@ -205,20 +157,20 @@ type osFile interface {
 
 // Add adds a single file to the tarfile, and starts a timer if the file is the
 // first file added.
-func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactory func(string) *time.Timer) {
+func (t *tarfile) Add(cleanedFilename filename.Internal, file osFile, timerFactory func(string) *time.Timer) {
 	if _, present := t.memberSet[cleanedFilename]; present {
-		pusherTarfileDuplicateFiles.WithLabelValues(t.root).Inc()
+		pusherTarfileDuplicateFiles.WithLabelValues(t.datatype).Inc()
 		log.Printf("Not adding %q to the tarfile a second time.\n", cleanedFilename)
 		return
 	}
 	fstat, err := file.Stat()
 	if err != nil {
-		pusherFileReadErrors.WithLabelValues(t.root).Inc()
+		pusherFileReadErrors.WithLabelValues(t.datatype).Inc()
 		log.Printf("Could not stat %s (error: %q)\n", cleanedFilename, err)
 		return
 	}
 	size := fstat.Size()
-	pusherBytesPerFile.WithLabelValues(t.root).Observe(float64(size))
+	pusherBytesPerFile.WithLabelValues(t.datatype).Observe(float64(size))
 	// We read the file into memory instead of using io.Copy because if the use of
 	// io.Copy goes wrong, then we have to make the error fatal (because the
 	// already-written tarfile headers are now wrong), while the reading of disk
@@ -231,12 +183,12 @@ func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactor
 	// `tarWriter.Write(contents)` line with `io.Copy(tarWriter, file)`.
 	contents := make([]byte, size)
 	if n, err := file.Read(contents); int64(n) != size || err != nil {
-		pusherFileReadErrors.WithLabelValues(t.root).Inc()
+		pusherFileReadErrors.WithLabelValues(t.datatype).Inc()
 		log.Printf("Could not read %s (error: %q)\n", cleanedFilename, err)
 		return
 	}
 	if n, err := file.Read(make([]byte, 1)); n != 0 || err != io.EOF {
-		pusherFileReadErrors.WithLabelValues(t.root).Inc()
+		pusherFileReadErrors.WithLabelValues(t.datatype).Inc()
 		log.Printf("Could not after reading %d bytes, %s was not at EOF (error: %q)\n", size, cleanedFilename, err)
 		return
 	}
@@ -258,9 +210,9 @@ func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactor
 	rtx.Must(t.gzipWriter.Flush(), "Could not flush the gzipWriter")
 
 	if len(t.members) == 0 {
-		t.timeout = timerFactory(t.subdir)
+		t.timeout = timerFactory(string(t.subdir))
 	}
-	pusherFilesAdded.WithLabelValues(t.root).Inc()
+	pusherFilesAdded.WithLabelValues(t.datatype).Inc()
 	t.members = append(t.members, file)
 	t.memberSet[cleanedFilename] = struct{}{}
 }
@@ -270,8 +222,8 @@ func (t *tarfile) Add(cleanedFilename InternalFilename, file osFile, timerFactor
 // method will keep trying until the upload succeeds.
 func (t *tarfile) UploadAndDelete(uploader uploader.Uploader) {
 	if len(t.members) == 0 {
-		pusherEmptyUploads.WithLabelValues(t.root).Inc()
-		pusherSuccessTimestamp.WithLabelValues(t.root).SetToCurrentTime()
+		pusherEmptyUploads.WithLabelValues(t.datatype).Inc()
+		pusherSuccessTimestamp.WithLabelValues(t.datatype).SetToCurrentTime()
 		log.Println("uploadAndDelete called on an empty tarfile.")
 		return
 	}
@@ -280,29 +232,29 @@ func (t *tarfile) UploadAndDelete(uploader uploader.Uploader) {
 	}
 	t.tarWriter.Close()
 	t.gzipWriter.Close()
-	pusherFilesPerTarfile.WithLabelValues(t.root).Observe(float64(len(t.members)))
-	pusherBytesPerTarfile.WithLabelValues(t.root).Observe(float64(t.contents.Len()))
+	pusherFilesPerTarfile.WithLabelValues(t.datatype).Observe(float64(len(t.members)))
+	pusherBytesPerTarfile.WithLabelValues(t.datatype).Observe(float64(t.contents.Len()))
 	bytes := t.contents.Bytes()
 	// Try to upload until the upload succeeds.
 	backoff.Retry(
 		func() error {
-			return uploader.Upload(t.subdir, bytes)
+			return uploader.Upload(string(t.subdir), bytes)
 		},
 		time.Duration(100)*time.Millisecond,
 		time.Duration(5)*time.Minute,
 		"upload",
 	)
-	pusherTarfilesUploaded.WithLabelValues(t.root).Inc()
-	pusherSuccessTimestamp.WithLabelValues(t.root).SetToCurrentTime()
+	pusherTarfilesUploaded.WithLabelValues(t.datatype).Inc()
+	pusherSuccessTimestamp.WithLabelValues(t.datatype).SetToCurrentTime()
 	for _, file := range t.members {
 		// If the file can't be removed, then it either was already removed or the
 		// remove call failed for some unknown reason (permissions, maybe?). If the
 		// file still exists after this attempted remove, then it should eventually
 		// get picked up by the finder.
 		if err := os.Remove(file.Name()); err == nil {
-			pusherFilesRemoved.WithLabelValues(t.root).Inc()
+			pusherFilesRemoved.WithLabelValues(t.datatype).Inc()
 		} else {
-			pusherFileRemoveErrors.WithLabelValues(t.root).Inc()
+			pusherFileRemoveErrors.WithLabelValues(t.datatype).Inc()
 			log.Printf("Failed to remove %v (error: %q)\n", file, err)
 		}
 	}

--- a/tarfile/tarfile_test.go
+++ b/tarfile/tarfile_test.go
@@ -12,43 +12,6 @@ import (
 	"github.com/m-lab/pusher/tarfile"
 )
 
-func TestLint(t *testing.T) {
-	for _, badString := range []string{
-		"/gfdgf/../fsdfds/data.txt",
-		"file.txt; rm -Rf *",
-		"dir/.gz",
-		"dir/.../file.gz",
-		"dir/only_a_dir/",
-		"ndt/2009/03/ab/file.gz",
-	} {
-		if tarfile.InternalFilename(badString).Lint() == nil {
-			t.Errorf("Should have had a lint error on %q", badString)
-		}
-	}
-	for _, goodString := range []string{
-		"ndt/2009/03/13/file.gz",
-		"experiment_2/2013/01/01/subdirectory/file.tgz",
-	} {
-		if warning := tarfile.InternalFilename(goodString).Lint(); warning != nil {
-			t.Errorf("Linter gave warning %v on %q", warning, goodString)
-		}
-	}
-}
-func TestSubdir(t *testing.T) {
-	for _, test := range []struct{ in, out string }{
-		{in: "2009/01/01/tes/", out: "2009/01/01"},
-		{in: "2009/01/test", out: "2009/01"},
-		{in: "2009/test", out: "2009"},
-		{in: "test", out: ""},
-		{in: "2009/01/01/subdir/test", out: "2009/01/01"},
-	} {
-		out := tarfile.InternalFilename(test.in).Subdir()
-		if out != test.out {
-			t.Errorf("The subdirectory should have been %q but was %q", test.out, out)
-		}
-	}
-}
-
 var timerFactoryCalls = 0
 
 func nilTimerFactory(string) *time.Timer {
@@ -89,7 +52,7 @@ func TestAdd(t *testing.T) {
 	rtx.Must(os.Chdir(tmp), "Could not chdir to the tempdir")
 	defer os.Chdir(oldDir)
 	timerFactoryCalls = 0
-	tf := tarfile.New(tmp, "")
+	tf := tarfile.New("test", "")
 	ioutil.WriteFile("tinyfile", []byte("abcdefgh"), os.FileMode(0666))
 	if tf.Size() != 0 {
 		t.Errorf("Tarfile size is nonzero before anything is added to it")
@@ -113,7 +76,7 @@ func TestAdd(t *testing.T) {
 	}
 }
 func TestUploadAndDeleteOnEmpty(t *testing.T) {
-	tf := tarfile.New("", "")
+	tf := tarfile.New("test", "")
 	tf.UploadAndDelete(nil) // If this doesn't crash, then the test passes.
 }
 
@@ -155,7 +118,7 @@ func TestUploadAndDelete(t *testing.T) {
 	f2, err := os.Open("disappearing")
 	rtx.Must(err, "Could not open file we just wrote")
 	rtx.Must(os.Remove("disappearing"), "Could not delete file")
-	tf := tarfile.New(tmp, "")
+	tf := tarfile.New("test", "")
 	timerFactory := func(string) *time.Timer { return time.NewTimer(time.Hour) }
 	tf.Add("tinyfile", f, timerFactory)
 	tf.Add("disappearing", f2, timerFactory)

--- a/tarfile/tarfile_test.go
+++ b/tarfile/tarfile_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/m-lab/go/rtx"
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/tarfile"
 )
 
@@ -87,8 +88,8 @@ type fakeUploader struct {
 	expectedDir      string
 }
 
-func (f *fakeUploader) Upload(dir string, contents []byte) error {
-	if f.expectedDir != "" && dir != f.expectedDir {
+func (f *fakeUploader) Upload(dir filename.System, contents []byte) error {
+	if f.expectedDir != "" && string(dir) != f.expectedDir {
 		log.Fatalf("Upload to unexpected directory: %v != %v\n", dir, f.expectedDir)
 	}
 	f.contents = contents

--- a/uploader/uploader.go
+++ b/uploader/uploader.go
@@ -6,13 +6,14 @@ import (
 	"time"
 
 	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/namer"
 	"golang.org/x/net/context"
 )
 
 // Uploader is an interface for uploading data.
 type Uploader interface {
-	Upload(dir string, contents []byte) error
+	Upload(dir filename.System, contents []byte) error
 }
 
 // We split the Uploader into a struct and Interface to allow for mocking of the
@@ -43,7 +44,7 @@ func Create(ctx context.Context, client stiface.Client, bucketName string, namer
 }
 
 // Upload the provided buffer to GCS.
-func (u *uploader) Upload(directory string, contents []byte) error {
+func (u *uploader) Upload(directory filename.System, contents []byte) error {
 	name := u.namer.ObjectName(directory, time.Now().UTC())
 	object := u.bucket.Object(name)
 	writer := object.NewWriter(u.context)

--- a/uploader/uploader_test.go
+++ b/uploader/uploader_test.go
@@ -11,6 +11,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/GoogleCloudPlatform/google-cloud-go-testing/storage/stiface"
+	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/uploader"
 	"golang.org/x/net/context"
 )
@@ -19,7 +20,7 @@ type testNamer struct {
 	newName string
 }
 
-func (tn testNamer) ObjectName(s string, t time.Time) string {
+func (tn testNamer) ObjectName(s filename.System, t time.Time) string {
 	return tn.newName
 }
 
@@ -27,10 +28,10 @@ func TestUploading(t *testing.T) {
 	buff := make([]byte, 16)
 	rand.Seed(time.Now().UnixNano())
 	rand.Read(buff)
-	dir := "TestUploading." + base64.RawURLEncoding.EncodeToString(buff) + "/"
+	dir := filename.System("TestUploading." + base64.RawURLEncoding.EncodeToString(buff) + "/")
 	fileName := dir + "test.txt"
 	namer := &testNamer{
-		newName: fileName,
+		newName: string(fileName),
 	}
 	ctx := context.Background()
 	client, err := storage.NewClient(ctx)
@@ -42,9 +43,9 @@ func TestUploading(t *testing.T) {
 	if err := up.Upload(dir, []byte(contents)); err != nil {
 		t.Error("Could not Upload():", err)
 	}
-	url := "https://storage.googleapis.com/archive-mlab-testing/" + fileName
+	url := "https://storage.googleapis.com/archive-mlab-testing/" + string(fileName)
 	defer func() {
-		cmd := exec.Command("gsutil", "rm", "-f", "gs://archive-mlab-testing/"+fileName)
+		cmd := exec.Command("gsutil", "rm", "-f", "gs://archive-mlab-testing/"+string(fileName))
 		cmd.Run()
 	}()
 


### PR DESCRIPTION
This allows us to have only one instance of pusher for a given pod, even if that pod is producing e.g. ndt summary data, tcpinfo data, and scamper data.

Fixes #37 and makes it possible to monitor pusher on the new platform in a more sensible way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/44)
<!-- Reviewable:end -->
