### PR TITLE
Add the -dry_run flag to enable the verification of the docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: go
 
+services:
+- docker
+
 before_install:
 - go get github.com/mattn/goveralls
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
@@ -21,3 +24,5 @@ script:
 - GCLOUD_PROJECT=mlab-testing
     go test -v -covermode=count -coverprofile=__coverage.cov -coverpkg=./... ./...
 - $HOME/gopath/bin/goveralls -coverprofile=__coverage.cov -service=travis-ci
+- docker build -t pushertest .
+- docker run pushertest --dry_run

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM golang:1.11 as build
 # Add the local files to be sure we are building the local source code instead
 # of downloading from GitHub.
 # Don't add any of the other libraries, because we live at HEAD.
+ENV CGO_ENABLED 0
 COPY . /go/src/github.com/m-lab/pusher
 RUN go get -v github.com/m-lab/pusher
 
@@ -17,4 +18,4 @@ WORKDIR /
 # To set the command-line args use their corresponding environment variables or
 # add the flags or args to the end of the "docker run measurementlab/pusher"
 # command.
-CMD ["/pusher"]
+ENTRYPOINT ["/pusher"]


### PR DESCRIPTION
Adds a `--dry_run` flag (and tests its usage).

The flag can be used (and now is used by Travis) to ensure that the actual binary can actually run inside the container that it ends up in.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/48)
<!-- Reviewable:end -->
