### PR TITLE
Preserve ModTime

### DIFF
--- a/listener/listener_test.go
+++ b/listener/listener_test.go
@@ -8,27 +8,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/pusher/filename"
 	"github.com/m-lab/pusher/listener"
 )
 
 func TestListenForClose(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "TestListenForClose.")
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
 	ldfChan := make(chan filename.System)
 	l, err := listener.Create(filename.System(dir), ldfChan)
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create listener")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go l.ListenForever(ctx)
-	ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777)
+	rtx.Must(ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777), "Could not write file")
 	ldf := <-ldfChan
 	if !strings.HasSuffix(string(ldf), "/testfile") || !strings.HasPrefix(string(ldf), "/tmp/TestListenForClose.") {
 		t.Errorf("Bad filename: %v\n", ldf)
@@ -37,27 +32,17 @@ func TestListenForClose(t *testing.T) {
 
 func TestListenForMove(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "TestListenForMove.")
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
 	os.Mkdir(dir+"/subdir", 0777)
-	ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777)
+	rtx.Must(ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777), "Could not write file")
 	ldfChan := make(chan filename.System)
 	l, err := listener.Create(filename.System(dir+"/subdir"), ldfChan)
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create listener")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go l.ListenForever(ctx)
-	err = os.Rename(dir+"/testfile", dir+"/subdir/testfile")
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(os.Rename(dir+"/testfile", dir+"/subdir/testfile"), "Could not rename")
 	ldf := <-ldfChan
 	if !strings.HasSuffix(string(ldf), "/subdir/testfile") || !strings.HasPrefix(string(ldf), "/tmp/TestListenForMove.") {
 		t.Errorf("Bad filename: %v\n", ldf)
@@ -66,25 +51,19 @@ func TestListenForMove(t *testing.T) {
 
 func TestListenInSubdir(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "TestListenInSubdir.")
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
 	os.Mkdir(dir+"/subdir", 0777)
 	ldfChan := make(chan filename.System)
 	l, err := listener.Create(filename.System(dir+"/subdir"), ldfChan)
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create listener")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go l.ListenForever(ctx)
 	os.MkdirAll(dir+"/subdir/sub1/sub2", 0777)
 	// Sleep to allow the subdirectory listener to be established.
 	time.Sleep(100 * time.Millisecond)
-	ioutil.WriteFile(dir+"/subdir/sub1/sub2/testfile", []byte("testdata"), 0777)
+	rtx.Must(ioutil.WriteFile(dir+"/subdir/sub1/sub2/testfile", []byte("testdata"), 0777), "Could not write file")
 	ldf := <-ldfChan
 	if dir+"/subdir/sub1/sub2/testfile" != string(ldf) {
 		t.Errorf("Bad filename: %v\n", ldf)
@@ -93,14 +72,33 @@ func TestListenInSubdir(t *testing.T) {
 
 func TestCreateOnBadDir(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "TestCreateOnBadDir.")
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create tempdir")
 	defer os.RemoveAll(dir)
 	ldfChan := make(chan filename.System)
 	l, err := listener.Create(filename.System(dir+"/doesnotexist"), ldfChan)
 	if l != nil || err == nil {
 		t.Error("Should have had an error")
+	}
+}
+
+func TestReadCloseWontNotify(t *testing.T) {
+	dir, err := ioutil.TempDir("/tmp", "TestReadCloseWontNotify.")
+	rtx.Must(err, "Could not create tempdir")
+	defer os.RemoveAll(dir)
+	rtx.Must(ioutil.WriteFile(dir+"/testfile", []byte("test"), 0777), "Could not write file")
+	ldfChan := make(chan filename.System)
+	l, err := listener.Create(filename.System(dir), ldfChan)
+	rtx.Must(err, "Could not create listener")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go l.ListenForever(ctx)
+	f, err := os.Open(dir + "/testfile")
+	rtx.Must(err, "Could not open file")
+	f.Read(make([]byte, 4))
+	rtx.Must(f.Close(), "Could not close file")
+	select {
+	case <-ldfChan:
+		t.Error("A read close should not cause an event")
+	case <-time.NewTimer(100 * time.Millisecond).C:
 	}
 }

--- a/listener/listener_whitebox_test.go
+++ b/listener/listener_whitebox_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/m-lab/go/rtx"
 	"github.com/m-lab/pusher/filename"
 	"github.com/rjeczalik/notify"
 	"golang.org/x/sys/unix"
@@ -41,17 +42,11 @@ func (m MockEventInfo) Sys() interface{} {
 
 func TestBadEvent(t *testing.T) {
 	dir, err := ioutil.TempDir("/tmp", "TestBadEvent.")
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create dir")
 	defer os.RemoveAll(dir)
 	ldfChan := make(chan filename.System)
 	l, err := Create(filename.System(dir), ldfChan)
-	if err != nil {
-		t.Errorf("%v", err)
-		return
-	}
+	rtx.Must(err, "Could not create listener")
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go l.ListenForever(ctx)

--- a/tarfile/tarfile.go
+++ b/tarfile/tarfile.go
@@ -179,9 +179,10 @@ func (t *tarfile) Add(cleanedFilename filename.Internal, file osFile, timerFacto
 		return
 	}
 	header := &tar.Header{
-		Name: string(cleanedFilename),
-		Mode: 0666,
-		Size: size,
+		Name:    string(cleanedFilename),
+		Mode:    0666,
+		Size:    size,
+		ModTime: fstat.ModTime(),
 	}
 
 	// It's not at all clear how any of the below errors might be recovered from,

--- a/tarfile/tarfile_test.go
+++ b/tarfile/tarfile_test.go
@@ -163,6 +163,14 @@ func TestTimestampsArePreserved(t *testing.T) {
 
 	s, err := os.Stat("tinyfile")
 	rtx.Must(err, "tinyfile should have been created")
+
+	// Unpreserved ModTimes result in Unix timestamp 0, which is before 1980.
+	//
+	// Testing whether the timestamp equals zero risks confusion due to
+	// timezones on the local filesystem and how the local tar command is
+	// configured and what the LC_LOCALE is, and probably other stuff because
+	// timezones are awful. We assume here that no timezone could possibly shift
+	// things by more than a decade.
 	if s.ModTime().Before(time.Date(1980, 1, 1, 1, 1, 1, 1, time.UTC)) {
 		t.Error("ModTime was not preserved")
 	}


### PR DESCRIPTION
Pusher now preserves the Mtime of the uploaded files in the tarfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/65)
<!-- Reviewable:end -->
