### PR TITLE
Allows cloud-node names like mlab1.abc0c.

### DIFF
--- a/pusher.go
+++ b/pusher.go
@@ -117,7 +117,7 @@ func signalHandler(sig os.Signal, termCancel context.CancelFunc, waitTime time.D
 // code here for itself.
 func mlabNameToNodeName(nodeName string) (string, error) {
 	// Extract M-Lab machine (mlab5) and site (abc0t) names from node FQDN (mlab5.abc0t.measurement-lab.org).
-	re := regexp.MustCompile(`^(mlab\d)\.([a-z]{3}\d[\dt])\.measurement-lab\.org$`)
+	re := regexp.MustCompile(`^(mlab\d)\.([a-z]{3}\d[\dtc])\.measurement-lab\.org$`)
 	if !re.MatchString(nodeName) {
 		return "", fmt.Errorf("Bad node name: %s", nodeName)
 	}

--- a/pusher_test.go
+++ b/pusher_test.go
@@ -15,6 +15,11 @@ func Test_mlabNameToNodeName(t *testing.T) {
 			want:     "mlab1-abc0t",
 		},
 		{
+			name:     "okay-cloud-name",
+			nodeName: "mlab1.abc0c.measurement-lab.org",
+			want:     "mlab1-abc0c",
+		},
+		{
 			name:     "failure-machine-too-short",
 			nodeName: "mlab.abc0t.measurement-lab.org",
 			wantErr:  true,


### PR DESCRIPTION
Cloud nodes will have a site name ending in "C". Currently, pusher doesn't allow this

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/68)
<!-- Reviewable:end -->
