### PR TITLE
Eliminate 2 hour sync, fix test races

### DIFF
--- a/tarcache/whitebox_test.go
+++ b/tarcache/whitebox_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/m-lab/go/flagx"
+	"github.com/m-lab/go/memoryless"
 
 	"github.com/m-lab/go/bytecount"
 	"github.com/m-lab/go/rtx"
@@ -112,7 +113,12 @@ func TestEmptyUpload(t *testing.T) {
 	}
 	uploader := fakeUploader{expectedDir: tempdir}
 	// Ignore the returned channel - this is a whitebox test.
-	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
+	config := memoryless.Config{
+		Min:      time.Duration(1 * time.Hour),
+		Expected: time.Duration(1 * time.Hour),
+		Max:      time.Duration(1 * time.Hour),
+	}
+	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	tarCache.currentTarfile[tempdir] = tarfile.New(filename.System(tempdir), "", make(map[string]string))
 	tarCache.uploadAndDelete("this does not exist")
 	tarCache.uploadAndDelete(tempdir)
@@ -141,7 +147,12 @@ func TestUnreadableFile(t *testing.T) {
 	}
 	uploader := fakeUploader{}
 	// Ignore the returned channel - this is a whitebox test.
-	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
+	config := memoryless.Config{
+		Min:      time.Duration(1 * time.Hour),
+		Expected: time.Duration(1 * time.Hour),
+		Max:      time.Duration(1 * time.Hour),
+	}
+	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	// This should not crash, even though the file does not exist.
 	tarCache.add(filename.System(tempdir + "/dne"))
 	if tf, ok := tarCache.currentTarfile[tempdir]; ok && tf.Size() != 0 {
@@ -176,7 +187,12 @@ func TestAdd(t *testing.T) {
 	kv := &flagx.KeyValue{}
 	rtx.Must(kv.Set("MLAB.testkey=testvalue"), "Could not set key to value")
 	// Ignore the returned channel - this is a whitebox test.
-	tarCache, _ := New(filename.System(tempdir), "testdata", kv, bytecount.ByteCount(1*bytecount.Kilobyte), time.Duration(1*time.Hour), &uploader)
+	config := memoryless.Config{
+		Min:      time.Duration(1 * time.Hour),
+		Expected: time.Duration(1 * time.Hour),
+		Max:      time.Duration(1 * time.Hour),
+	}
+	tarCache, _ := New(filename.System(tempdir), "testdata", kv, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	if len(tarCache.currentTarfile) != 0 {
 		t.Errorf("The file list should be of zero length and is not (%d != 0)", len(tarCache.currentTarfile))
 	}

--- a/tarcache/whitebox_test.go
+++ b/tarcache/whitebox_test.go
@@ -114,9 +114,9 @@ func TestEmptyUpload(t *testing.T) {
 	uploader := fakeUploader{expectedDir: tempdir}
 	// Ignore the returned channel - this is a whitebox test.
 	config := memoryless.Config{
-		Min:      time.Duration(1 * time.Hour),
-		Expected: time.Duration(1 * time.Hour),
-		Max:      time.Duration(1 * time.Hour),
+		Min:      1 * time.Hour,
+		Expected: 1 * time.Hour,
+		Max:      1 * time.Hour,
 	}
 	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	tarCache.currentTarfile[tempdir] = tarfile.New(filename.System(tempdir), "", make(map[string]string))
@@ -148,9 +148,9 @@ func TestUnreadableFile(t *testing.T) {
 	uploader := fakeUploader{}
 	// Ignore the returned channel - this is a whitebox test.
 	config := memoryless.Config{
-		Min:      time.Duration(1 * time.Hour),
-		Expected: time.Duration(1 * time.Hour),
-		Max:      time.Duration(1 * time.Hour),
+		Min:      1 * time.Hour,
+		Expected: 1 * time.Hour,
+		Max:      1 * time.Hour,
 	}
 	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	// This should not crash, even though the file does not exist.
@@ -188,9 +188,9 @@ func TestAdd(t *testing.T) {
 	rtx.Must(kv.Set("MLAB.testkey=testvalue"), "Could not set key to value")
 	// Ignore the returned channel - this is a whitebox test.
 	config := memoryless.Config{
-		Min:      time.Duration(1 * time.Hour),
-		Expected: time.Duration(1 * time.Hour),
-		Max:      time.Duration(1 * time.Hour),
+		Min:      1 * time.Hour,
+		Expected: 1 * time.Hour,
+		Max:      1 * time.Hour,
 	}
 	tarCache, _ := New(filename.System(tempdir), "testdata", kv, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	if len(tarCache.currentTarfile) != 0 {


### PR DESCRIPTION
Should address #71 , but monitoring after deployment will be the real determiner of success.

This PR also includes fixes for race conditions discovered in unit tests. The code itself was not found to be racy, but some unit tests were.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/73)
<!-- Reviewable:end -->
