### PR TITLE
Track pusher_finder_mtime_lower_bound

### DIFF
--- a/finder/findfiles_test.go
+++ b/finder/findfiles_test.go
@@ -28,7 +28,7 @@ func TestFindForever(t *testing.T) {
 	foundFiles := make(chan filename.System)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	go finder.FindForever(ctx, filename.System(tempdir), time.Duration(6)*time.Hour, foundFiles, 1*time.Microsecond)
+	go finder.FindForever(ctx, "test", filename.System(tempdir), time.Duration(6)*time.Hour, foundFiles, 1*time.Microsecond)
 	localfiles := []filename.System{
 		<-foundFiles,
 		<-foundFiles,
@@ -50,7 +50,7 @@ func TestFindForeverNoDirExists(t *testing.T) {
 	tempdir, err := ioutil.TempDir("/tmp", "find_file_test")
 	defer os.RemoveAll(tempdir)
 	rtx.Must(err, "Could not set up temp dir")
-	go finder.FindForever(ctx, "/tmp/dne", time.Duration(time.Millisecond), nil, time.Duration(time.Millisecond))
+	go finder.FindForever(ctx, "dne", "/tmp/dne", time.Duration(time.Millisecond), nil, time.Duration(time.Millisecond))
 	time.Sleep(1 * time.Second)
 	// If the finder doesn't crash on a bad directory, then it's a success.
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20191008195207-8e1d251e947d
 	github.com/m-lab/go v1.2.1
 	github.com/prometheus/client_golang v1.3.0
+	github.com/prometheus/prometheus v2.5.0+incompatible // indirect
 	github.com/rjeczalik/notify v0.9.2
 	golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553
 	golang.org/x/sys v0.0.0-20191220142924-d4481acd189f

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/prometheus/prometheus v2.5.0+incompatible h1:7QPitgO2kOFG8ecuRn9O/4L9+10He72rVRJvMXrE9Hg=
+github.com/prometheus/prometheus v2.5.0+incompatible/go.mod h1:oAIUtOny2rjMX0OWN5vPR5/q/twIROJvdqnQKDdil/s=
 github.com/rjeczalik/notify v0.9.2 h1:MiTWrPj55mNDHEiIX5YUSKefw/+lCQVoAFmD6oQm5w8=
 github.com/rjeczalik/notify v0.9.2/go.mod h1:aErll2f0sUX9PXZnVNyeiObbmTlk5jnMoCa4QEjJeqM=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pusher.go
+++ b/pusher.go
@@ -213,7 +213,7 @@ M-Lab uniform naming conventions.
 		go l.ListenForever(ctx)
 
 		// Send very old or missed files to the tarCache as a cleanup precaution.
-		go finder.FindForever(ctx, datadir, *maxFileAge, pusherChannel, *cleanupInterval)
+		go finder.FindForever(ctx, datatype, datadir, *maxFileAge, pusherChannel, *cleanupInterval)
 	}
 
 	// Wait until every TarCache.ListenForever loop has terminated. Once every loop


### PR DESCRIPTION
By request. Metric should prevent nasty surprises (like the ones we already had).

Fixes #79 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/81)
<!-- Reviewable:end -->
