### PR TITLE
Slightly looser regexp matching on nodeName

### DIFF
--- a/pusher.go
+++ b/pusher.go
@@ -122,7 +122,7 @@ func signalHandler(sig os.Signal, termCancel context.CancelFunc, waitTime time.D
 // code here for itself.
 func mlabNameToNodeName(nodeName string) (string, error) {
 	// Extract M-Lab machine (mlab5) and site (abc0t) names from node FQDN (mlab5.abc0t.measurement-lab.org).
-	re := regexp.MustCompile(`^(mlab\d)\.([a-z]{3}\d[\dtc])\.measurement-lab\.org$`)
+	re := regexp.MustCompile(`^(mlab\d)\.([a-z]{3}\d[\dtc])`)
 	if !re.MatchString(nodeName) {
 		return "", fmt.Errorf("Bad node name: %s", nodeName)
 	}

--- a/pusher.go
+++ b/pusher.go
@@ -123,10 +123,11 @@ func signalHandler(sig os.Signal, termCancel context.CancelFunc, waitTime time.D
 func mlabNameToNodeName(nodeName string) (string, error) {
 	// Extract M-Lab machine (mlab5) and site (abc0t) names from node FQDN (mlab5.abc0t.measurement-lab.org).
 	re := regexp.MustCompile(`^(mlab\d)[.-]([a-z]{3}\d[\dtc])`)
-	if !re.MatchString(nodeName) {
+	matches := re.FindAllStringSubmatch(nodeName, -1)
+	if len(matches) != 1 || len(matches[0]) != 3 {
 		return "", fmt.Errorf("Bad node name: %s", nodeName)
 	}
-	return re.ReplaceAllString(nodeName, "$1-$2"), nil
+	return fmt.Sprintf("%s-%s", matches[0][1], matches[0][2]), nil
 }
 
 func main() {

--- a/pusher.go
+++ b/pusher.go
@@ -122,7 +122,7 @@ func signalHandler(sig os.Signal, termCancel context.CancelFunc, waitTime time.D
 // code here for itself.
 func mlabNameToNodeName(nodeName string) (string, error) {
 	// Extract M-Lab machine (mlab5) and site (abc0t) names from node FQDN (mlab5.abc0t.measurement-lab.org).
-	re := regexp.MustCompile(`^(mlab\d)\.([a-z]{3}\d[\dtc])`)
+	re := regexp.MustCompile(`^(mlab\d)[.-]([a-z]{3}\d[\dtc])`)
 	if !re.MatchString(nodeName) {
 		return "", fmt.Errorf("Bad node name: %s", nodeName)
 	}

--- a/pusher_test.go
+++ b/pusher_test.go
@@ -10,8 +10,13 @@ func Test_mlabNameToNodeName(t *testing.T) {
 		wantErr  bool
 	}{
 		{
-			name:     "okay-name",
+			name:     "okay-dotted-name",
 			nodeName: "mlab1.abc0t.measurement-lab.org",
+			want:     "mlab1-abc0t",
+		},
+		{
+			name:     "okay-dashed-name",
+			nodeName: "mlab1-abc0t.measurement-lab.org",
 			want:     "mlab1-abc0t",
 		},
 		{


### PR DESCRIPTION
This PR unbounds the end of the regexp used in `mlabNameToNodeName` and removes the domain "measurement-lab.org" to allow us flexibility in which domain name we are using. This change is in anticipation of us moving to project-decorated nodes names (e.g., mlab1.den05.mlab-oti.measurement-lab.org). The current regexp does not match these new node names.

This also substitutes the use of `re.ReplaceAllString()` with `re.FindAllStringSubmatch()` because the former doesn't behave as we want when the regexp does not contain "measurement-lab.org".

Additionally, this PR changes the regexp to allow for a dashed ("flat") host part of the domain name. Currently, we only published dotted nodes names (e.g., mlab1.den05.measurement-lab.org), but in the future we may chose to flatten these names too (e.g., mlab1-den05.measurement-lab.org). This latter change is somewhat exploratory, as we have not all agreed on whether we will ever flatten node names in addition to experiment names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/91)
<!-- Reviewable:end -->
