### PR TITLE
Use complete mode for creating dirs

### DIFF
--- a/pusher.go
+++ b/pusher.go
@@ -193,7 +193,7 @@ M-Lab uniform naming conventions.
 
 		datadir := filename.System(path.Join(*directory, datatype))
 		// Make the directory (does nothing if the directory already exists)
-		rtx.Must(os.MkdirAll(string(datadir), 0666), "Could not create %s", datadir)
+		rtx.Must(os.MkdirAll(string(datadir), os.ModePerm), "Could not create %s", datadir)
 
 		// Set up the file-bundling tarcache system.
 		config := memoryless.Config{


### PR DESCRIPTION
While preparing directions for revtr to use pusher to upload archives to thirdparty-revrt, I discovered that the directory creation performed by pusher used the wrong mode, making directories without the 'x' bit set.

This change uses the default, complete `os.ModePerm` value to set the 'x' bits correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/97)
<!-- Reviewable:end -->
