### PR TITLE
Don't make datatype directories

### DIFF
--- a/pusher.go
+++ b/pusher.go
@@ -200,8 +200,6 @@ M-Lab uniform naming conventions.
 		uploader := uploader.Create(ctx, *uploadTimeout, stiface.AdaptClient(client), *bucket, namer)
 
 		datadir := filename.System(path.Join(*directory, datatype))
-		// Make the directory (does nothing if the directory already exists)
-		rtx.Must(os.MkdirAll(string(datadir), os.ModePerm), "Could not create %s", datadir)
 
 		// Set up the file-bundling tarcache system.
 		config := memoryless.Config{


### PR DESCRIPTION
Pusher shouldn't be making the datatype directories. Instead the sidecar that creates the data should do this. Not only does this seem more correct, but it avoid permission issues where pusher and other sidecars are running as different users (i.e., Pusher is root, others are not).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/102)
<!-- Reviewable:end -->
