### PR TITLE
Enable pusher to only upload a specific file ratio per datatype

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
       -v `pwd`/fakedata:/var/spool/fakedata
       -v $TRAVIS_BUILD_DIR:/creds
       -e GOOGLE_APPLICATION_CREDENTIALS=/creds/creds.json
-      pushertest --dry_run --directory /var/spool --datatype fakedata
+      pushertest --dry_run --directory /var/spool --datatype fakedata=1

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	cloud.google.com/go/storage v1.22.0
 	github.com/googleapis/google-cloud-go-testing v0.0.0-20210719221736-1c9a4c676720
-	github.com/m-lab/go v0.1.66
+	github.com/m-lab/go v0.1.73
 	github.com/prometheus/client_golang v1.11.0
 	github.com/rjeczalik/notify v0.9.2
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4

--- a/go.sum
+++ b/go.sum
@@ -224,8 +224,8 @@ github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFB
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/m-lab/go v0.1.66 h1:adDJILqKBCkd5YeVhCrrjWkjoNRtDzlDr6uizWu5/pE=
-github.com/m-lab/go v0.1.66/go.mod h1:O1D/EoVarJ8lZt9foANcqcKtwxHatBzUxXFFyC87aQQ=
+github.com/m-lab/go v0.1.73 h1:vy4MRcEyvYOhfA55V6tT/NZlrfWS0qTNJktIrLaAbmw=
+github.com/m-lab/go v0.1.73/go.mod h1:BirARfHWjjXHaCGNyWCm/CKW1OarjuEj8Yn6Z2rc0M4=
 github.com/mattn/go-runewidth v0.0.10/go.mod h1:RAqKPSqVFrSLVXbA8x7dzmKdmGzieGRCM46jaSJTDAk=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=

--- a/pusher.go
+++ b/pusher.go
@@ -64,7 +64,7 @@ func init() {
 	// Set up the size flag with a custom parser.
 	flag.Var(&sizeThreshold, "archive_size_threshold", "The minimum tarfile size we require to commence upload (1KB, 200MB, etc). Default is 20MB")
 	// Set up the datatype flag with the appropriate parser.
-	flag.Var(&datatypes, "datatype", "Key-value pairs of datatypes to their file percentage. This argument should appear at least once, and may appear multiple times.")
+	flag.Var(&datatypes, "datatype", "Key-value pairs of datatypes to their file upload ratio. This argument should appear at least once, and may appear multiple times.")
 	// Set up the metadata flag with the appropriate parser
 	flag.Var(&metadata, "metadata", "Key-value pairs to be added to the metadata of each tarfile (flag may be repeated)")
 }
@@ -193,8 +193,8 @@ M-Lab uniform naming conventions.
 
 	// Set up pushing for every datatype.
 	for datatype, value := range datatypes.Get() {
-		pct, err := strconv.ParseFloat(value, 64)
-		rtx.Must(err, "Failed to parse datatype push percentage")
+		ratio, err := strconv.ParseFloat(value, 64)
+		rtx.Must(err, "Failed to parse datatype upload ratio")
 		// Set up the upload system.
 		namer := namer.New(datatype, *experiment, *nodeName)
 		client, err := storage.NewClient(ctx)
@@ -211,7 +211,7 @@ M-Lab uniform naming conventions.
 			Max:      *ageMax,
 		}
 		rtx.Must(config.Check(), "Tarfile age configs make no sense.")
-		tc, pusherChannel := tarcache.New(datadir, datatype, pct, &metadata, sizeThreshold, config, uploader)
+		tc, pusherChannel := tarcache.New(datadir, datatype, ratio, &metadata, sizeThreshold, config, uploader)
 		wg.Add(1)
 		go func() {
 			tc.ListenForever(termContext, killContext)

--- a/pusher_integration_test.go
+++ b/pusher_integration_test.go
@@ -44,7 +44,7 @@ func TestMainDoesCrashOnEmptyDatatypes(t *testing.T) {
 		}
 	}()
 
-	datatypes = []string{}
+	datatypes = flagx.KeyValue{}
 	main()
 }
 
@@ -124,7 +124,7 @@ func TestListenerTarcacheAndUploader(t *testing.T) {
 		return
 	}
 
-	tarCache, pusherChannel := tarcache.New(filename.System(tempdir), "test", &flagx.KeyValue{}, 1, memoryless.Config{}, up)
+	tarCache, pusherChannel := tarcache.New(filename.System(tempdir), "test", 1, &flagx.KeyValue{}, 1, memoryless.Config{}, up)
 	go tarCache.ListenForever(ctx, ctx)
 
 	// Set up the listener on the temp directory.
@@ -238,7 +238,7 @@ func TestListenerTarcacheAndUploaderWithOneFailure(t *testing.T) {
 		return
 	}
 
-	tarCache, pusherChannel := tarcache.New(filename.System(tempdir), "testdata", &flagx.KeyValue{}, 1, memoryless.Config{}, up)
+	tarCache, pusherChannel := tarcache.New(filename.System(tempdir), "testdata", 1, &flagx.KeyValue{}, 1, memoryless.Config{}, up)
 	go tarCache.ListenForever(ctx, ctx)
 
 	// Set up the listener on the temp directory.

--- a/pusher_integration_test.go
+++ b/pusher_integration_test.go
@@ -68,7 +68,7 @@ func TestMainDoesntCrash(t *testing.T) {
 		{"EXPERIMENT", "exp"},
 		{"MLAB_NODE_NAME", "mlab5.abc1t.measurement-lab.org"},
 		{"MONITORING_ADDRESS", "localhost:9000"},
-		{"DATATYPE", "testdata"},
+		{"DATATYPE", "testdata=1"},
 	}
 	for i := range newVars {
 		revert := osx.MustSetenv(newVars[i].name, newVars[i].value)

--- a/tarcache/tarcache.go
+++ b/tarcache/tarcache.go
@@ -57,7 +57,6 @@ type TarCache struct {
 	currentTarfile map[string]tarfile.Tarfile
 	sizeThreshold  bytecount.ByteCount
 	ageThreshold   memoryless.Config
-	uploadFile     map[string]bool
 	fileRatio      float64 // Ratio of individual files to be added to the tarcache [0, 1].
 	rootDirectory  filename.System
 	uploader       uploader.Uploader

--- a/tarcache/tarcache_test.go
+++ b/tarcache/tarcache_test.go
@@ -63,7 +63,7 @@ func TestTimer(t *testing.T) {
 		Expected: 100 * time.Millisecond,
 		Max:      100 * time.Millisecond,
 	}
-	tarCache, channel := tarcache.New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, uploader)
+	tarCache, channel := tarcache.New(filename.System(tempdir), "test", 1, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, uploader)
 	// Add the small file, which should not trigger an upload.
 	tinyFile := filename.System("a/b/tinyfile")
 	otherTinyFile := filename.System("c/d/tinyfile")
@@ -119,7 +119,7 @@ func TestContextCancellation(t *testing.T) {
 		Expected: 100 * time.Hour,
 		Max:      100 * time.Hour,
 	}
-	tarCache, fileChan := tarcache.New(filename.System("/tmp"), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Gigabyte), config, &uploader)
+	tarCache, fileChan := tarcache.New(filename.System("/tmp"), "test", 1, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Gigabyte), config, &uploader)
 	killCtx, killCancel := context.WithCancel(context.Background())
 	termCtx, termCancel := context.WithCancel(killCtx)
 
@@ -186,7 +186,7 @@ func TestChannelCloseCancellation(t *testing.T) {
 		Expected: 100 * time.Millisecond,
 		Max:      100 * time.Millisecond,
 	}
-	tarCache, inputChannel := tarcache.New(filename.System("/tmp"), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
+	tarCache, inputChannel := tarcache.New(filename.System("/tmp"), "test", 1, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	ctx := context.Background()
 	go func() {
 		time.Sleep(100 * time.Millisecond)

--- a/tarcache/whitebox_test.go
+++ b/tarcache/whitebox_test.go
@@ -119,7 +119,7 @@ func TestEmptyUpload(t *testing.T) {
 		Max:      1 * time.Hour,
 	}
 	tarCache, _ := New(filename.System(tempdir), "test", 1, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
-	tarCache.currentTarfile[tempdir] = tarfile.New(filename.System(tempdir), "", make(map[string]string))
+	tarCache.currentTarfile[tempdir] = tarfile.New(filename.System(tempdir), "", 1, make(map[string]string))
 	tarCache.uploadAndDelete("this does not exist")
 	tarCache.uploadAndDelete(tempdir)
 	if uploader.calls != 0 {

--- a/tarcache/whitebox_test.go
+++ b/tarcache/whitebox_test.go
@@ -151,6 +151,7 @@ func TestSkipFile(t *testing.T) {
 		Expected: 1 * time.Hour,
 		Max:      1 * time.Hour,
 	}
+	// File ratio = 0 means all files should be skipped.
 	tarCache, _ := New(filename.System(tempdir), "test", 0, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 
 	ioutil.WriteFile(tempdir+"/skipfile", []byte("abcdefgh"), os.FileMode(0666))

--- a/tarcache/whitebox_test.go
+++ b/tarcache/whitebox_test.go
@@ -118,7 +118,7 @@ func TestEmptyUpload(t *testing.T) {
 		Expected: 1 * time.Hour,
 		Max:      1 * time.Hour,
 	}
-	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
+	tarCache, _ := New(filename.System(tempdir), "test", 1, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	tarCache.currentTarfile[tempdir] = tarfile.New(filename.System(tempdir), "", make(map[string]string))
 	tarCache.uploadAndDelete("this does not exist")
 	tarCache.uploadAndDelete(tempdir)
@@ -138,6 +138,28 @@ func TestEmptyUpload(t *testing.T) {
 	tarCache.uploadAndDelete(tempdir)
 }
 
+func TestSkipFile(t *testing.T) {
+	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestSkipFile")
+	defer os.RemoveAll(tempdir)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	uploader := fakeUploader{}
+	config := memoryless.Config{
+		Min:      1 * time.Hour,
+		Expected: 1 * time.Hour,
+		Max:      1 * time.Hour,
+	}
+	tarCache, _ := New(filename.System(tempdir), "test", 0, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
+
+	ioutil.WriteFile(tempdir+"/skipfile", []byte("abcdefgh"), os.FileMode(0666))
+	tarCache.add(filename.System(tempdir + "/skipfile"))
+	if tf, ok := tarCache.currentTarfile[tempdir]; ok && tf.Size() != 0 {
+		t.Error("File should not have been added to the tarCache.")
+	}
+}
+
 func TestUnreadableFile(t *testing.T) {
 	tempdir, err := ioutil.TempDir("/tmp", "tarcache.TestUnreadableFile")
 	defer os.RemoveAll(tempdir)
@@ -152,7 +174,7 @@ func TestUnreadableFile(t *testing.T) {
 		Expected: 1 * time.Hour,
 		Max:      1 * time.Hour,
 	}
-	tarCache, _ := New(filename.System(tempdir), "test", &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
+	tarCache, _ := New(filename.System(tempdir), "test", 1, &flagx.KeyValue{}, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	// This should not crash, even though the file does not exist.
 	tarCache.add(filename.System(tempdir + "/dne"))
 	if tf, ok := tarCache.currentTarfile[tempdir]; ok && tf.Size() != 0 {
@@ -192,7 +214,7 @@ func TestAdd(t *testing.T) {
 		Expected: 1 * time.Hour,
 		Max:      1 * time.Hour,
 	}
-	tarCache, _ := New(filename.System(tempdir), "testdata", kv, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
+	tarCache, _ := New(filename.System(tempdir), "testdata", 1, kv, bytecount.ByteCount(1*bytecount.Kilobyte), config, &uploader)
 	if len(tarCache.currentTarfile) != 0 {
 		t.Errorf("The file list should be of zero length and is not (%d != 0)", len(tarCache.currentTarfile))
 	}

--- a/tarfile/tarfile.go
+++ b/tarfile/tarfile.go
@@ -173,6 +173,7 @@ func (t *tarfile) Add(cleanedFilename filename.Internal, file osFile, timerFacto
 	// Check if file should be skipped.
 	if rand.Float64() >= t.fileRatio {
 		t.skipped[filename.System(cleanedFilename)] = struct{}{}
+		pusherFilesSkipped.WithLabelValues(t.datatype).Inc()
 		return
 	}
 

--- a/tarfile/tarfile.go
+++ b/tarfile/tarfile.go
@@ -278,6 +278,8 @@ func (t tarfile) Size() bytecount.ByteCount {
 	return bytecount.ByteCount(t.contents.Len())
 }
 
+// SkippedCount returns the number of files skipped in the tarfile given
+// the datatype's file upload ratio.
 func (t tarfile) SkippedCount() int {
 	return len(t.skipped)
 }


### PR DESCRIPTION
This PR adds a mechanism for pusher to only upload a certain ratio of files for a datatype.

The `-datatype` flag now takes in key-value pairs of datatype names to their file ratio (e.g., `-datatype=ndt7=1,pcap=0.1`). 

It adds a `skipped` map to the `Tarfile` implementation to keep track of files that should be skipped from the `Tarfile` and removed when they otherwise would have been uploaded.

It also adds a "condition" label to some of the existing metrics to differentiate between added and skipped files and it adds a `pusher_files_skipped_total` counter to keep track of skipped files.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/105)
<!-- Reviewable:end -->
