### PR TITLE
Use the absolute path to remove skipped files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
 # good assumption, but one we should note.
 - GCLOUD_PROJECT=mlab-testing
     go test -v -covermode=count -coverprofile=__coverage.cov -coverpkg=./... ./...
-- $HOME/gopath/bin/goveralls -coverprofile=__coverage.cov -service=travis-ci
+- $HOME/gopath/bin/goveralls -coverprofile=__coverage.cov -service=travis-pro
 - docker build -t pushertest .
 - mkdir fakedata;
     docker run

--- a/tarfile/tarfile.go
+++ b/tarfile/tarfile.go
@@ -113,7 +113,7 @@ var (
 type tarfile struct {
 	timeout    *time.Timer
 	members    map[filename.Internal]filename.System
-	skipped    map[filename.System]struct{}
+	skipped    map[filename.Internal]filename.System
 	contents   *bytes.Buffer
 	tarWriter  *tar.Writer
 	gzipWriter *gzip.Writer
@@ -144,7 +144,7 @@ func New(subdir filename.System, datatype string, ratio float64, metadata map[st
 		tarWriter:  tarWriter,
 		gzipWriter: gzipWriter,
 		members:    make(map[filename.Internal]filename.System),
-		skipped:    make(map[filename.System]struct{}),
+		skipped:    make(map[filename.Internal]filename.System),
 		subdir:     subdir,
 		datatype:   datatype,
 		fileRatio:  ratio,
@@ -164,7 +164,7 @@ type osFile interface {
 // first file added.
 func (t *tarfile) Add(cleanedFilename filename.Internal, file osFile, timerFactory func(string) *time.Timer) {
 	// Check if file has already been skipped.
-	if _, present := t.skipped[filename.System(cleanedFilename)]; present {
+	if _, present := t.skipped[cleanedFilename]; present {
 		pusherTarfileDuplicateFiles.WithLabelValues(t.datatype, skipFile).Inc()
 		log.Printf("Not adding %q to the skipped files a second time.\n", cleanedFilename)
 		return
@@ -172,7 +172,7 @@ func (t *tarfile) Add(cleanedFilename filename.Internal, file osFile, timerFacto
 
 	// Check if file should be skipped.
 	if rand.Float64() >= t.fileRatio {
-		t.skipped[filename.System(cleanedFilename)] = struct{}{}
+		t.skipped[cleanedFilename] = filename.System(file.Name())
 		pusherFilesSkipped.WithLabelValues(t.datatype).Inc()
 		return
 	}
@@ -241,7 +241,7 @@ func (t *tarfile) Add(cleanedFilename filename.Internal, file osFile, timerFacto
 // method will keep trying until the upload succeeds.
 func (t *tarfile) UploadAndDelete(uploader uploader.Uploader) {
 	// Delete skipped files.
-	for filename := range t.skipped {
+	for _, filename := range t.skipped {
 		t.removeFile(filename, skipFile)
 	}
 


### PR DESCRIPTION
This PR updates the `skipped` map to point to the file name to use for removal. Previously, it using the relative path and throwing the errors of the form `"remove 2024/07/16/ndt-6d84n_1721076637_0000000000012392.pcap.gz: no such file or directory")`. The unit test did not catch this because the file system is local.

The container logs are clear now and the sandbox alerts are resolved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/pusher/106)
<!-- Reviewable:end -->
